### PR TITLE
proposed fix for #174: declare the dependency on pyOpenSSL even when the 

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,28 @@
 User visible changes in Foolscap (aka newpb/pb2).           -*- outline -*-
 
+** setuptools dependencies updated
+
+Foolscap (when built with setuptools) now declares that it needs pyOpenSSL 
+even if you don't specify that you want to use the "secure_connections"
+feature. This is because the Foolscap package sometimes doesn't declare the
+existence of the "secure_connections" feature even when it has it, so other
+packages can't rely that declaration. (It fails to declare this extra feature
+if it was built on a system without setuptools or if it was installed using the
+"pip" installer instead of "easy_install". pip is increasingly popular and is
+the officially recommended tool on the front page of
+http://pypi.python.org/pypi .)
+
+A consequence of this is that when you install Foolscap (with "python setup.py
+install" if you have setuptools installed, or with "easy_install Foolscap" or
+"pip Foolscap", or by installing a package that depends on Foolscap), then it
+will pull in pyOpenSSL if pyOpenSSL is not already installed in addition to 
+pulling in Twisted if Twisted is not already installed.
+
+If you want to install it without pulling in pyOpenSSL, then you can add the
+--no-deps option to the command-line for "setup.py install", "easy_install", or
+"pip", in which case you may need to manually install Twisted before you can
+use foolscap. (#174)
+
 * Release 0.6.1 (16-Jan-2011)
 
 ** Minor Fixes

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import re
+import re, sys
 from distutils.core import setup
 
 VERSIONFILE = "foolscap/_version.py"
@@ -51,6 +51,12 @@ object reference system, and a capability-based security model.
         'scripts': ["bin/flogtool", "bin/flappserver", "bin/flappclient"],
 }
 
+if '--no-deps' in sys.argv:
+    sys.argv.remove('--no-deps')
+else:
+    setup_args['install_requires'] = ['twisted >= 2.4.0', 'pyOpenSSL']
+    setup_args['extras_require'] = { 'secure_connections' : ["pyOpenSSL"] }
+
 have_setuptools = False
 try:
     # If setuptools is installed, then we'll add setuptools-specific
@@ -71,11 +77,16 @@ if have_setuptools:
             "flappserver = foolscap.appserver.cli:run_flappserver",
             "flappclient = foolscap.appserver.client:run_flappclient",
             ] }
-    setup_args['install_requires'] = ['twisted >= 2.4.0']
-    setup_args['extras_require'] = { 'secure_connections' : ["pyOpenSSL"] }
-    # note that pyOpenSSL-0.7 and recent Twisted causes unit test failures,
-    # see bug #62
 
 if __name__ == '__main__':
-    setup(**setup_args)
-
+    # If we passed the 'install_requires' and 'extras_require'
+    # arguments and they are not recognized by the setup() function
+    # then that is okay -- suppress the warning.
+    import warnings
+    try:
+        warnings.filterwarnings("ignore", category=UserWarning,
+                                message="Unknown distribution option",
+                                append=True)
+        setup(**setup_args)
+    finally:
+        warnings.filters.pop()


### PR DESCRIPTION
proposed fix for #174: declare the dependency on pyOpenSSL even when the secure_connections feature wasn't requested

http://foolscap.lothar.com/trac/ticket/174
