### PR TITLE
Tub.setOption('log-gatherer-furl', x) now accepts an iterable of log gath

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2011-06-24  Zooko O'Whielacronx  <zooko@zooko.com>
+
+	* foolscap/pb.py (Tub): accept an iterable of log gatherer furls
+	in addition to a single log gatherer furl. Closes #176
+	* test/test_logging.py (Gatherer): test for same
+
 2011-06-09  Brian Warner  <warner@lothar.com>
 
 	* foolscap/test/test_appserver.py (RunCommand.test_run): use a

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,12 @@
 User visible changes in Foolscap (aka newpb/pb2).           -*- outline -*-
 
+* Release ___ (future)
+
+** API Changes
+
+*** setOption now accepts an iterable of log gatherer furls or a single log 
+    gatherer furl for its 'log-gatherer-furl' option. (#176)
+
 * Release 0.6.1 (16-Jan-2011)
 
 ** Minor Fixes

--- a/doc/logging.xhtml
+++ b/doc/logging.xhtml
@@ -572,13 +572,20 @@ either tell the Tub a specific gatherer to use, or give it a filename where
 the FURL of a log gatherer is stored.</p>
 
 <p>The <code>tub.setOption("log-gatherer-furl", gatherer_FURL)</code> call
-can be used to have the Tub automatically connect to the log gatherer and
-offer its logport. The Tub uses a Reconnector to make sure the gatherer
-connection is reestablished each time it gets dropped.</p>
+can be used to have the Tub automatically connect to one or more log
+gatherers and offer its logport. The Tub uses a Reconnector to make sure the
+gatherer connection is reestablished each time it gets dropped.</p>
 
 <pre class="python">
 t = Tub()
 t.setOption("log-gatherer-furl", gatherer_FURL)
+</pre>
+
+or
+
+<pre class="python">
+t = Tub()
+t.setOption("log-gatherer-furl", gatherer_FURLs)
 </pre>
 
 

--- a/foolscap/logging/publish.py
+++ b/foolscap/logging/publish.py
@@ -155,10 +155,11 @@ class LogPublisher(Referenceable):
      logport_furlfile = 'logport.furl'
      tub.setOption('logport-furlfile', logport_furlfile)
 
-    If you're using a LogGatherer, pass its FURL into the Tub with
-    tub.setOption('log-gatherer-furl'), or pass the name of a file where it
-    is stored with tub.setOption('log-gatherer-furlfile'). This will cause
-    the Tub to connect to the gatherer and grant it access to the logport.
+    If you're using one or more LogGatherers, pass their FURLs into the Tub
+    with tub.setOption('log-gatherer-furl'), or pass the name of a file
+    where it is stored with tub.setOption('log-gatherer-furlfile'). This
+    will cause the Tub to connect to the gatherer and grant it access to the
+    logport.
     """
 
     implements(RILogPublisher)

--- a/foolscap/pb.py
+++ b/foolscap/pb.py
@@ -321,7 +321,7 @@ class Tub(service.MultiService):
         self._logport_furl = None
         self._logport_furlfile = None
 
-        self._log_gatherer_furl = None
+        self._log_gatherer_furls = []
         self._log_gatherer_furlfile = None
         self._log_gatherer_connectors = {} # maps furl to reconnector
 
@@ -377,8 +377,11 @@ class Tub(service.MultiService):
             raise KeyError("unknown option name '%s'" % name)
 
     def setLogGathererFURL(self, gatherer_furl):
-        assert not self._log_gatherer_furl
-        self._log_gatherer_furl = gatherer_furl
+        assert not self._log_gatherer_furls
+        if isinstance(gatherer_furl, basestring):
+            self._log_gatherer_furls.append(gatherer_furl)
+        else:
+            self._log_gatherer_furls.extend(gatherer_furl)
         self._maybeConnectToGatherer()
 
     def setLogGathererFURLFile(self, gatherer_furlfile):
@@ -390,8 +393,8 @@ class Tub(service.MultiService):
         if not self.locationHints:
             return
         furls = []
-        if self._log_gatherer_furl:
-            furls.append(self._log_gatherer_furl)
+        if self._log_gatherer_furls:
+            furls.extend(self._log_gatherer_furls)
         if self._log_gatherer_furlfile:
             try:
                 # allow multiple lines


### PR DESCRIPTION
Tub.setOption('log-gatherer-furl', x) now accepts an iterable of log gatherer
furls in addition to accepting a single log gatherer furl
fixes #176
ref. Tahoe-LAFS ticket http://tahoe-lafs.org/trac/tahoe-lafs/ticket/1423
(support multiple log gatherers using the new multi-gatherer feature of
foolscap)
