### PR TITLE
trying to remove all reactor imports from top level

### DIFF
--- a/foolscap/banana.py
+++ b/foolscap/banana.py
@@ -1,7 +1,7 @@
 
 import struct, time
 
-from twisted.internet import protocol, defer, reactor
+from twisted.internet import protocol, defer
 from twisted.python.failure import Failure
 from twisted.python import log
 
@@ -130,6 +130,8 @@ class Banana(protocol.Protocol):
             print "Banana.connectionMade"
         self.initSlicer()
         self.initUnslicer()
+        from twisted.internet import reactor
+        
         if self.keepaliveTimeout is not None:
             self.dataLastReceivedAt = time.time()
             t = reactor.callLater(self.keepaliveTimeout + EPSILON,

--- a/foolscap/banana.py
+++ b/foolscap/banana.py
@@ -660,6 +660,8 @@ class Banana(protocol.Protocol):
         if age > self.keepaliveTimeout:
             # the connection looks idle, so let's provoke a response
             self.sendPING()
+            
+        from twisted.internet import reactor
         # we restart the timer in either case
         t = reactor.callLater(self.keepaliveTimeout + EPSILON,
                               self.keepaliveTimerFired)
@@ -677,6 +679,7 @@ class Banana(protocol.Protocol):
             # be the right thing to do, perhaps we should restart it
             # unconditionally.
         else:
+            from twisted.internet import reactor
             # we're still ok, so restart the timer
             t = reactor.callLater(self.disconnectTimeout + EPSILON,
                                   self.disconnectTimerFired)

--- a/foolscap/eventual.py
+++ b/foolscap/eventual.py
@@ -1,6 +1,6 @@
 # -*- test-case-name: foolscap.test.test_eventual -*-
 
-from twisted.internet import reactor, defer
+from twisted.internet import defer
 from twisted.python import log
 
 class _SimpleCallQueue(object):
@@ -13,6 +13,7 @@ class _SimpleCallQueue(object):
     def append(self, cb, args, kwargs):
         self._events.append((cb, args, kwargs))
         if not self._timer:
+            from twisted.internet import reactor
             self._timer = reactor.callLater(0, self._turn)
 
     def _turn(self):

--- a/foolscap/logging/gatherer.py
+++ b/foolscap/logging/gatherer.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     pass
 from zope.interface import implements
-from twisted.internet import reactor, utils, defer
+from twisted.internet import utils, defer
 from twisted.python import usage, procutils, filepath, log as tw_log
 from twisted.application import service, internet
 from foolscap.api import Tub, Referenceable
@@ -157,6 +157,7 @@ class GathererService(GatheringBase):
         self._savefile = None
 
     def _handle_SIGHUP(self, *args):
+        from twisted.internet import reactor
         reactor.callFromThread(self.do_rotate)
 
     def startService(self):

--- a/foolscap/logging/incident.py
+++ b/foolscap/logging/incident.py
@@ -3,7 +3,6 @@ import sys, os.path, time, pickle, bz2
 from pprint import pprint
 from zope.interface import implements
 from twisted.python import usage
-from twisted.internet import reactor
 from foolscap.logging.interfaces import IIncidentReporter
 from foolscap.logging import levels, app_versions
 from foolscap.eventual import eventually
@@ -118,6 +117,7 @@ class IncidentReporter:
             self.active = False
             eventually(self.finished_recording)
         else:
+            from twisted.internet import reactor
             # now we wait for the trailing events to arrive
             self.timer = reactor.callLater(self.TRAILING_DELAY,
                                            self.stop_recording)

--- a/foolscap/negotiate.py
+++ b/foolscap/negotiate.py
@@ -2,7 +2,7 @@
 
 import time
 from twisted.python.failure import Failure
-from twisted.internet import protocol, reactor
+from twisted.internet import protocol
 
 from foolscap import broker, referenceable, vocab
 from foolscap.eventual import eventually
@@ -265,6 +265,9 @@ class Negotiation(protocol.Protocol):
         if (self.options.has_key("debug_slow_%s" % name) and
             not self.debugTimers.has_key(name)):
             self.log("debug_doTimer(%s)" % name)
+            
+            from twisted.internet import reactor
+            
             t = reactor.callLater(timeout, self.debug_fireTimer, name)
             self.debugTimers[name] = (t, [(call, args)])
             cb = self.options["debug_slow_%s" % name]
@@ -355,6 +358,7 @@ class Negotiation(protocol.Protocol):
             return
         timeout = self.options.get('server_timeout', self.SERVER_TIMEOUT)
         if timeout:
+            from twisted.internet import reactor
             # oldpb clients will hit this case.
             self.negotiationTimer = reactor.callLater(timeout,
                                                       self.negotiationTimedOut)
@@ -1324,6 +1328,8 @@ class TubConnector(object):
         This will either result in the successful Negotiation object invoking
         the parent Tub's brokerAttached() method, our us calling the Tub's
         connectionFailed() method."""
+        from twisted.internet import reactor
+        
         self.tub.connectorStarted(self)
         if not self.remainingLocations:
             # well, that's going to make it difficult. connectToAll() will
@@ -1353,6 +1359,7 @@ class TubConnector(object):
         # invoke self.tub.connectorFinished()
 
     def connectToAll(self):
+        from twisted.internet import reactor
         while self.remainingLocations:
             location = self.remainingLocations.pop()
             if location in self.attemptedLocations:

--- a/foolscap/reconnector.py
+++ b/foolscap/reconnector.py
@@ -2,7 +2,6 @@
 
 import random
 import time
-from twisted.internet import reactor
 from twisted.python import log
 from foolscap.tokens import NegotiationError, RemoteNegotiationError
 
@@ -133,6 +132,8 @@ class Reconnector(object):
         if self.verbose:
             log.msg("Reconnector scheduling retry in %ds for %s" %
                     (self._delay, self._url))
+            
+        from twisted.internet import reactor
         self._timer = reactor.callLater(self._delay, self._timer_expired)
 
     def _timer_expired(self):

--- a/foolscap/util.py
+++ b/foolscap/util.py
@@ -1,6 +1,6 @@
 
 import socket
-from twisted.internet import defer, reactor, protocol
+from twisted.internet import defer, protocol
 
 
 class AsyncAND(defer.Deferred):
@@ -70,6 +70,9 @@ def get_local_ip_for(target='A.ROOT-SERVERS.NET'):
     except socket.gaierror:
         # DNS isn't running
         return None
+    
+    from twisted.internet import reactor
+    
     udpprot = protocol.DatagramProtocol()
     port = reactor.listenUDP(0, udpprot)
     try:


### PR DESCRIPTION
Because of reactor import on top level, we can't install any other reactor in our application later, only before load of any module, which is not convenient, especially if you're going to run application on different platforms (like epoll reactor for linux, kqueue reactor for BSD).

I've faced with problem in my project - nodeset.core, which reuses a lot of twistd code to run application and --reactor option is not working then.

Thank you
