### PR TITLE
Zeroconf hint and Avahi support

### DIFF
--- a/foolscap/discovery/__init__.py
+++ b/foolscap/discovery/__init__.py
@@ -1,0 +1,13 @@
+
+try:
+    import avahi_publish
+    import avahi_discover
+    PublishTub = avahi_publish.AvahiPublishTub
+    DiscoverTubs = avahi_discover.AvahiDiscoverTubs
+except:
+    raise
+
+supported_hints = {"zeroconf": (DiscoverTubs, PublishTub)}
+
+def start_discovery_using(hint, addcb, remcb):
+    return supported_hints[hint][0](addcb, remcb)

--- a/foolscap/discovery/avahi_discover.py
+++ b/foolscap/discovery/avahi_discover.py
@@ -1,0 +1,66 @@
+import dbus
+import avahi
+from collections import namedtuple
+from twisted.application import service
+from dbus.mainloop.glib import DBusGMainLoop
+DBusGMainLoop(set_as_default=True)
+
+ResolvedService = namedtuple("ResolvedService",
+                             ["iface", "proto", "name", "type", "domain",
+                              "host", "aproto", "addr", "port", "txt", "flags"])
+
+class AvahiDiscoverTubs(service.Service):
+    SERVICE_TYPE = "_foolscap-rpc._tcp"
+    def __init__(self, addcb, remcb):
+        self.dbus = self.browser = None
+        self._addcb = addcb
+        self._remcb = remcb
+        self.known_services = {}
+
+    def startService(self):
+        self.__dbus_connect()
+        service.Service.startService(self)
+
+    def __dbus_connect(self):
+        bus = dbus.SystemBus()
+        self.dbus = dbus.Interface(
+                bus.get_object( avahi.DBUS_NAME, avahi.DBUS_PATH_SERVER ),
+                avahi.DBUS_INTERFACE_SERVER )
+
+        self.browser = dbus.Interface(bus.get_object(avahi.DBUS_NAME,
+                                          self.dbus.ServiceBrowserNew(
+                                                                        avahi.IF_UNSPEC,
+                                                                        avahi.PROTO_INET,
+                                                                        self.SERVICE_TYPE,
+                                                                        '',
+                                                                        0
+                                                                        )
+                                            ),
+                                      avahi.DBUS_INTERFACE_SERVICE_BROWSER)
+        self.browser.connect_to_signal("ItemNew", self.__new_service)
+        self.browser.connect_to_signal("ItemRemove", self.__remove_service)
+    
+    def __new_service(self, iface, proto, name, stype, domain, flags):
+        def service_resolved(*args):
+            args = ResolvedService(*args)
+            self.known_services[args[2]] = args
+            self._addcb(args)
+
+        def service_resolve_error(*args):
+            pass
+        
+        self.dbus.ResolveService(iface, proto, name, stype, domain,
+                                   avahi.PROTO_UNSPEC, dbus.UInt32(0),
+                                   reply_handler=service_resolved,
+                                   error_handler=service_resolve_error)
+
+    def __remove_service(self, iface, proto, name, stype, domain, flags):
+        self._remcb(self.known_services[name])
+        del self.known_services[name]
+
+if __name__ == "__main__":
+    from twisted.internet import glib2reactor
+    glib2reactor.install()
+    from twisted.internet import reactor
+    disco = AvahiDiscoverTahoeNodes()
+    reactor.run()

--- a/foolscap/discovery/avahi_publish.py
+++ b/foolscap/discovery/avahi_publish.py
@@ -1,0 +1,84 @@
+import dbus
+import avahi
+
+#from twisted.internet import glib2reactor
+#glib2reactor.install()
+
+from dbus.mainloop.glib import DBusGMainLoop
+DBusGMainLoop(set_as_default=True)
+
+class AvahiPublishTub:
+    SERVICE_TYPE = "_foolscap-rpc._tcp"
+
+    def __init__(self, tub):
+        self.dbus = None
+        self.groups = {} 
+        self.tub = tub
+        self.collisionfix = 0
+
+    def __dbus_connect(self):
+        self.sys_dbus = dbus.SystemBus()
+
+        self.dbus = dbus.Interface(
+                self.sys_dbus.get_object( avahi.DBUS_NAME, avahi.DBUS_PATH_SERVER ),
+                avahi.DBUS_INTERFACE_SERVER )
+
+    def __avahi_new_group(self, listener):
+        group = dbus.Interface(
+                self.sys_dbus.get_object( avahi.DBUS_NAME, self.dbus.EntryGroupNew()),
+                avahi.DBUS_INTERFACE_ENTRY_GROUP)
+        
+        group.connect_to_signal('StateChanged', self.__dbus_state_change(listener))
+        return group
+
+    def __dbus_state_change(self, listener):
+        def cb(state, what):
+            if state == avahi.SERVER_COLLISION:
+                self.__resolve_collision(listener)
+        return cb
+
+    def __resolve_collision(self, listener):
+        self.collisionfix += 1
+        self.listenOn(listener)
+
+    def listenOn(self, listener):
+        if not self.dbus:
+            self.__dbus_connect()
+
+        name = self.tub.getTubID()
+        if self.collisionfix > 0:
+            name += " #%d" % self.collisionfix
+
+        if listener not in self.groups:
+            group = self.groups[listener] = self.__avahi_new_group(listener)
+        
+        add_service(
+                group,
+                name,
+                self.SERVICE_TYPE,
+                "",
+                "",
+                listener.getPortnum(),
+                repr(self.tub.parent)
+                )
+            
+    def stopListeningOn(self, listener):
+        try:
+            self.groups[listener].Reset()
+        except KeyError:
+            pass
+        else:
+            del self.groups[listener]
+#endclass
+
+def add_service(group, name, stype, domain, host, port, txt):
+    group.AddService(
+            avahi.IF_UNSPEC,
+            avahi.PROTO_UNSPEC,
+            dbus.UInt32(avahi.PUBLISH_UPDATE), # flags
+            name, stype,
+            domain, host,
+            dbus.UInt16(port),
+            avahi.string_array_to_txt_array(txt))
+    group.Commit()
+


### PR DESCRIPTION
This adds a "zeroconf" token to the hint list. Might want to consider changing that since it's also a valid hostname?

It uses _foolscap-rpc._tcp for the mDNS-SD service name, which is technically invalid as it needs registering on dns-sd.org.

I'm also not entirely sure how the reconnect system works so it might stop doing the avahi discovery permanently after it gets connected. This should be pretty easy to fix just by toggling the discovery_enabled var back on at the right moment though.

Not expecting this to get pulled yet, but thought you might have some pointers to tidy it up :)
