### PR TITLE
Make Violation messages for arguments and answers include the method name

### DIFF
--- a/foolscap/broker.py
+++ b/foolscap/broker.py
@@ -603,7 +603,7 @@ class Broker(banana.Banana, referenceable.Referenceable):
                                   (delivery.obj, methodSchema.name))
                 raise
 
-        answer = call.AnswerSlicer(reqID, res)
+        answer = call.AnswerSlicer(reqID, res, methodSchema.name)
         # once the answer has started transmitting, any exceptions must be
         # logged and dropped, and not turned into an Error to be sent.
         try:

--- a/foolscap/call.py
+++ b/foolscap/call.py
@@ -104,21 +104,22 @@ class PendingRequest(object):
 class ArgumentSlicer(slicer.ScopedSlicer):
     opentype = ('arguments',)
 
-    def __init__(self, args, kwargs):
+    def __init__(self, args, kwargs, methodname="?"):
         slicer.ScopedSlicer.__init__(self, None)
         self.args = args
         self.kwargs = kwargs
         self.which = ""
+        self.methodname = methodname
 
     def sliceBody(self, streamable, banana):
         yield len(self.args)
         for i,arg in enumerate(self.args):
-            self.which = "arg[%d]" % i
+            self.which = "arg[%d]-of-%s" % (i, self.methodname)
             yield arg
         keys = self.kwargs.keys()
         keys.sort()
         for argname in keys:
-            self.which = "arg[%s]" % argname
+            self.which = "arg[%s]-of-%s" % (argname, self.methodname)
             yield argname
             yield self.kwargs[argname]
 
@@ -141,7 +142,7 @@ class CallSlicer(slicer.ScopedSlicer):
         yield self.reqID
         yield self.clid
         yield self.methodname
-        yield ArgumentSlicer(self.args, self.kwargs)
+        yield ArgumentSlicer(self.args, self.kwargs, self.methodname)
 
     def describe(self):
         return "<call-%s-%s-%s>" % (self.reqID, self.clid, self.methodname)
@@ -573,18 +574,19 @@ class CallUnslicer(slicer.ScopedUnslicer):
 class AnswerSlicer(slicer.ScopedSlicer):
     opentype = ('answer',)
 
-    def __init__(self, reqID, results):
+    def __init__(self, reqID, results, methodname="?"):
         assert reqID != 0
         slicer.ScopedSlicer.__init__(self, None)
         self.reqID = reqID
         self.results = results
+        self.methodname = methodname
 
     def sliceBody(self, streamable, banana):
         yield self.reqID
         yield self.results
 
     def describe(self):
-        return "<answer-%s>" % self.reqID
+        return "<answer-%s-to-%s>" % (self.reqID, self.methodname)
 
 class AnswerUnslicer(slicer.ScopedUnslicer):
     request = None


### PR DESCRIPTION
Make Violation messages for arguments and answers include the method name. fixes #201

Signed-off-by: David-Sarah Hopwood david-sarah@jacaranda.org
