### PR TITLE
accept new-style connection hints

### DIFF
--- a/foolscap/negotiate.py
+++ b/foolscap/negotiate.py
@@ -1314,7 +1314,7 @@ class TubConnector(object):
         # filter out the hints that we can actually use.. there may be
         # extensions from the future sitting in this list
         for h in self.target.getLocations():
-            if h[0] == "ipv4":
+            if h[0] == "tcp":
                 (host, port) = h[1:]
                 hints.append( (host, port) )
         self.remainingLocations = hints

--- a/foolscap/test/test_gifts.py
+++ b/foolscap/test/test_gifts.py
@@ -452,7 +452,7 @@ class Bad(Base, unittest.TestCase):
             (encrypted, tubid, location_hints, name) = \
                 decode_furl(adave.tracker.url)
             # highly unlikely that there's anything listening on this port
-            location_hints = [ ("ipv4", "127.0.0.1", 2) ]
+            location_hints = [ ("tcp", "127.0.0.1", 2) ]
             adave.tracker.url = encode_furl(encode_furl, tubid,
                                             location_hints, name)
             return self.shouldFail(ConnectionRefusedError, "Bad.test_location",
@@ -477,7 +477,7 @@ class Bad(Base, unittest.TestCase):
             # connection timeout.
             (encrypted, tubid, location_hints, name) = \
                 decode_furl(adave.tracker.url)
-            location_hints = [ ("ipv4", "127.0.0.1", p.getHost().port) ]
+            location_hints = [ ("tcp", "127.0.0.1", p.getHost().port) ]
             adave.tracker.url = encode_furl(encode_furl, tubid,
                                             location_hints, name)
             self.tubD.options['connect_timeout'] = 2

--- a/foolscap/test/test_pb.py
+++ b/foolscap/test/test_pb.py
@@ -436,7 +436,7 @@ class TestCallable(unittest.TestCase):
             self.failUnlessEqual(rref.getRemoteTubID(), self.tubB.getTubID())
             self.failUnlessEqual(rref.isConnected(), True)
             self.failUnlessEqual(rref.getLocationHints(),
-                                 [('ipv4', '127.0.0.1', self.tub_ports[1])])
+                                 [('tcp', '127.0.0.1', self.tub_ports[1])])
         d.addCallback(_check)
         return d
 

--- a/foolscap/test/test_sturdyref.py
+++ b/foolscap/test/test_sturdyref.py
@@ -10,7 +10,14 @@ class URL(unittest.TestCase):
         sr = SturdyRef("pb://%s@127.0.0.1:9900/name" % TUB1)
         self.failUnlessEqual(sr.tubID, TUB1)
         self.failUnlessEqual(sr.locationHints,
-                             [ ("ipv4", "127.0.0.1", 9900) ])
+                             [ ("tcp", "127.0.0.1", 9900) ])
+        self.failUnlessEqual(sr.name, "name")
+
+    def testURLTcp(self):
+        sr = SturdyRef("pb://%s@tcp:host=127.0.0.1:port=9900/name" % TUB1)
+        self.failUnlessEqual(sr.tubID, TUB1)
+        self.failUnlessEqual(sr.locationHints,
+                             [ ("tcp", "127.0.0.1", 9900) ])
         self.failUnlessEqual(sr.name, "name")
 
     def testTubIDExtensions(self):
@@ -24,7 +31,7 @@ class URL(unittest.TestCase):
         furl = "pb://%s@127.0.0.1:9900,udp:127.0.0.1:7700/name" % TUB1
         sr = SturdyRef(furl)
         self.failUnlessEqual(sr.locationHints,
-                             [ ("ipv4", "127.0.0.1", 9900) ])
+                             [ ("tcp", "127.0.0.1", 9900) ])
         self.failUnlessEqual(sr.getURL(), furl)
 
         furl = "pb://%s@udp:127.0.0.1:7700/name" % TUB1
@@ -54,27 +61,14 @@ class URL(unittest.TestCase):
         sr = SturdyRef(url)
         self.failUnlessEqual(sr.tubID, TUB1)
         self.failUnlessEqual(sr.locationHints,
-                             [ ("ipv4", "127.0.0.1", 9900),
-                               ("ipv4", "remote", 8899) ])
+                             [ ("tcp", "127.0.0.1", 9900),
+                               ("tcp", "remote", 8899) ])
         self.failUnlessEqual(sr.name, "name")
 
     def testBrokenHints(self):
-        # This should throw an exception
-        furl = "pb://%s@127.0.0.1/name" % TUB1 # missing portnum
-        f = self.failUnlessRaises(BadFURLError, SturdyRef, furl)
-        def _check(f, hostname):
-            self.failUnless(("bad connection hint '%s' "
-                             "(hostname, but no port)" % hostname) in str(f),
-                            f)
-        _check(f, "127.0.0.1")
-
-        furl = "pb://%s@example.com/name" % TUB1 # missing portnum
-        f = self.failUnlessRaises(BadFURLError, SturdyRef, furl)
-        _check(f, "example.com")
-
         furl = "pb://%s@,/name" % TUB1 # empty hints are not allowed
         f = self.failUnlessRaises(BadFURLError, SturdyRef, furl)
-        _check(f, "")
+        self.failUnless("empty string" in str(f), f)
 
         furl = "pb://%s@/name" % TUB1 # this is ok, and means "unrouteable"
         sr = SturdyRef(furl)

--- a/foolscap/test/test_tub.py
+++ b/foolscap/test/test_tub.py
@@ -108,7 +108,7 @@ class SetLocation(unittest.TestCase):
             if sr.encrypted:
                 for lh in sr.locationHints:
                     self.failUnlessEqual(lh[2], portnum, lh)
-                self.failUnless( ("ipv4", "127.0.0.1", portnum)
+                self.failUnless( ("tcp", "127.0.0.1", portnum)
                                  in sr.locationHints)
             else:
                 # TODO: unauthenticated tubs need review, I think they


### PR DESCRIPTION
Accept TCP connection hints in the new Twisted Endpoints syntax (e.g.
"tcp:host=127.0.0.1:port=9999").

Also, be more picky about what we take to be an old-style host:port connection
hint (for example, accept only a certain class of characters in hostnames, and
accept only port numbers that are 1 to 5 digits long).

If a connection hint is neither a new-style TCP Endpoint string, nor matches
the (now tighter) old-style host:port string, then it will be ignored. (This
makes it easy for future versions of foolscap to put other forms of connection
hints into furls, knowing that foolscap 0.7 will ignore them.)

Also, we no longer require ignored connection hints to contain a ':'.
