### PR TITLE
accept all formats of new-style connection hints

### DIFF
--- a/foolscap/referenceable.py
+++ b/foolscap/referenceable.py
@@ -787,9 +787,116 @@ def encode_location_hint(hint):
     host, port = hint[1:]
     return "%s:%d" % (host, port)
 
+# _tokenize(), _parse() and _parseClientTCP() are copied from
+# twisted.internet.endpoints
+
+_OP, _STRING = range(2)
+
+def _tokenize(description):
+    """
+    Tokenize a strports string and yield each token.
+
+    @param description: a string as described by L{serverFromString} or
+        L{clientFromString}.
+
+    @return: an iterable of 2-tuples of (L{_OP} or L{_STRING}, string).  Tuples
+        starting with L{_OP} will contain a second element of either ':' (i.e.
+        'next parameter') or '=' (i.e. 'assign parameter value').  For example,
+        the string 'hello:greet\=ing=world' would result in a generator
+        yielding these values::
+
+            _STRING, 'hello'
+            _OP, ':'
+            _STRING, 'greet=ing'
+            _OP, '='
+            _STRING, 'world'
+    """
+    current = ''
+    ops = ':='
+    nextOps = {':': ':=', '=': ':'}
+    description = iter(description)
+    for n in description:
+        if n in ops:
+            yield _STRING, current
+            yield _OP, n
+            current = ''
+            ops = nextOps[n]
+        elif n == '\\':
+            current += description.next()
+        else:
+            current += n
+    yield _STRING, current
+
+def _parse(description):
+    """
+    Convert a description string into a list of positional and keyword
+    parameters, using logic vaguely like what Python does.
+
+    @param description: a string as described by L{serverFromString} or
+        L{clientFromString}.
+
+    @return: a 2-tuple of C{(args, kwargs)}, where 'args' is a list of all
+        ':'-separated C{str}s not containing an '=' and 'kwargs' is a map of
+        all C{str}s which do contain an '='.  For example, the result of
+        C{_parse('a:b:d=1:c')} would be C{(['a', 'b', 'c'], {'d': '1'})}.
+    """
+    args, kw = [], {}
+    def add(sofar):
+        if len(sofar) == 1:
+            args.append(sofar[0])
+        else:
+            kw[sofar[0]] = sofar[1]
+    sofar = ()
+    for (type, value) in _tokenize(description):
+        if type is _STRING:
+            sofar += (value,)
+        elif value == ':':
+            add(sofar)
+            sofar = ()
+    add(sofar)
+    return args, kw
+
+def _parseClientTCP(*args, **kwargs):
+    """
+    Perform any argument value coercion necessary for TCP client parameters.
+
+    Valid positional arguments to this function are host and port.
+
+    Valid keyword arguments to this function are all L{IReactorTCP.connectTCP}
+    arguments.
+
+    @return: The coerced values as a C{dict}.
+    """
+
+    if len(args) == 2:
+        kwargs['port'] = int(args[1])
+        kwargs['host'] = args[0]
+    elif len(args) == 1:
+        if 'host' in kwargs:
+            kwargs['port'] = int(args[0])
+        else:
+            kwargs['host'] = args[0]
+
+    try:
+        kwargs['port'] = int(kwargs['port'])
+    except KeyError:
+        pass
+
+    try:
+        kwargs['timeout'] = int(kwargs['timeout'])
+    except KeyError:
+        pass
+
+    try:
+        kwargs['bindAddress'] = (kwargs['bindAddress'], 0)
+    except KeyError:
+        pass
+
+    return kwargs
+
 # Each location hint must start with "TYPE:" (where TYPE is alphanumeric) and
 # then can contain any characters except "," and "/". These are expected to
-# look like Twisted endpoin descriptors, or contain other ":"-separated
+# look like Twisted endpoint descriptors, or contain other ":"-separated
 # fields (e.g. "TYPE:key=value:key=value" or "TYPE:stuff:morestuff"). We also
 # accept old-syle implicit TCP hints (host:port). To avoid being interpreted
 # as an old-style hint, the part after TYPE: may not consist of only 1-5
@@ -800,7 +907,10 @@ def encode_location_hint(hint):
 # of hints:
 #
 #  HOST:PORT                 (implicit tcp)
-#  tcp:host=HOST:port=POST   (endpoint syntax for TCP connections)
+#  tcp:host=HOST:port=PORT }
+#  tcp:HOST:PORT           } (endpoint syntax for TCP connections
+#  tcp:host=HOST:PORT      }  in full, compact and mixed forms)
+#  tcp:HOST:port=PORT      }
 
 def decode_location_hints(hints_s):
     hints = []
@@ -815,10 +925,12 @@ def decode_location_hints(hints_s):
                 hint = ( "tcp", mo.group(1), int(mo.group(2)) )
                 hints.append(hint)
             else:
-                pieces = hint_s.split(':')
-                if pieces[0] == 'tcp':
-                    fields = dict([f.split("=") for f in pieces[1:]])
-                    hint = ("tcp", fields["host"], int(fields["port"]))
+                args, kwargs = _parse(hint_s)
+                aname = args.pop(0)
+                name = aname.upper()
+                if name == 'TCP':
+                    fields = _parseClientTCP(*args, **kwargs)
+                    hint = ("tcp", fields["host"], fields["port"])
                     hints.append(hint)
                 else:
                     # Ignore other things from the future.

--- a/foolscap/test/test_sturdyref.py
+++ b/foolscap/test/test_sturdyref.py
@@ -13,12 +13,32 @@ class URL(unittest.TestCase):
                              [ ("tcp", "127.0.0.1", 9900) ])
         self.failUnlessEqual(sr.name, "name")
 
-    def testURLTcp(self):
+    def testEndpointsURLTcp(self):
         sr = SturdyRef("pb://%s@tcp:host=127.0.0.1:port=9900/name" % TUB1)
         self.failUnlessEqual(sr.tubID, TUB1)
         self.failUnlessEqual(sr.locationHints,
                              [ ("tcp", "127.0.0.1", 9900) ])
         self.failUnlessEqual(sr.name, "name")
+
+    def testEndpointsURLTcpCompact(self):
+        sr = SturdyRef("pb://%s@tcp:127.0.0.1:9900/name" % TUB1)
+        self.failUnlessEqual(sr.tubID, TUB1)
+        self.failUnlessEqual(sr.locationHints,
+                             [ ("tcp", "127.0.0.1", 9900) ])
+        self.failUnlessEqual(sr.name, "name")
+
+    def testEndpointsURLTcpMixed(self):
+        sr1 = SturdyRef("pb://%s@tcp:host=127.0.0.1:9900/name" % TUB1)
+        sr2 = SturdyRef("pb://%s@tcp:127.0.0.1:port=9900/name" % TUB1)
+        self.failUnlessEqual(sr1, sr2)
+        self.failUnlessEqual(sr1.tubID, TUB1)
+        self.failUnlessEqual(sr1.locationHints,
+                             [ ("tcp", "127.0.0.1", 9900) ])
+        self.failUnlessEqual(sr1.name, "name")
+        self.failUnlessEqual(sr2.tubID, TUB1)
+        self.failUnlessEqual(sr2.locationHints,
+                             [ ("tcp", "127.0.0.1", 9900) ])
+        self.failUnlessEqual(sr2.name, "name")
 
     def testTubIDExtensions(self):
         sr = SturdyRef("pb://%s,otherstuff@127.0.0.1:9900/name" % TUB1)


### PR DESCRIPTION
Accept TCP connection hints in the new Twisted Endpoints syntax, for all possible parameter permutations.

Uses the internal Endpoints parsers, which requires Twisted>=10.1.
