### PR TITLE
foolscap/__init__.py: __version__ should be a byte string

### DIFF
--- a/foolscap/__init__.py
+++ b/foolscap/__init__.py
@@ -1,5 +1,5 @@
 """Foolscap"""
 
 from ._version import get_versions
-__version__ = get_versions()['version']
+__version__ = str(get_versions()['version'])
 del get_versions


### PR DESCRIPTION
This fixes the tests run on released versions that complain that
"u'X.Y.Z' is not a valid bytestring".