### PR TITLE
tor connection-handler

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,9 @@ object reference system, and a capability-based security model.
     "cmdclass": commands,
     "install_requires": ["twisted[tls] >= 16.0.0", "pyOpenSSL"],
     "extras_require": {
-        "dev": ["mock", "txsocksx"],
+        "dev": ["mock", "txsocksx", "txtorcon >= 0.15.0"],
         "socks": ["txsocksx"],
+        "tor": ["txtorcon >= 0.15.0"],
         },
 }
 

--- a/src/foolscap/connections/tor.py
+++ b/src/foolscap/connections/tor.py
@@ -1,0 +1,167 @@
+import os, re
+from twisted.internet.interfaces import IStreamClientEndpoint
+from twisted.internet.defer import inlineCallbacks, returnValue, succeed
+import ipaddress
+from .. import observer
+
+from zope.interface import implementer
+from ..ipb import IConnectionHintHandler, InvalidHintError
+from ..util import allocate_tcp_port
+import txtorcon
+from .tcp import DOTTED_QUAD_RESTR, DNS_NAME_RESTR
+
+def is_non_public_numeric_address(host):
+    # for numeric hostnames, skip RFC1918 addresses, since no Tor exit
+    # node will be able to reach those. Likewise ignore IPv6 addresses.
+    try:
+        a = ipaddress.ip_address(host.decode("ascii")) # wants unicode
+    except ValueError:
+        return False # non-numeric, let Tor try it
+    if a.version != 4:
+        return True # IPv6 gets ignored
+    if (a.is_loopback or a.is_multicast or a.is_private or a.is_reserved
+        or a.is_unspecified):
+        return True # too weird, don't connect
+    return False
+
+HINT_RE = re.compile(r"^[^:]*:(%s|%s):(\d+){1,5}$" % (DOTTED_QUAD_RESTR,
+                                                      DNS_NAME_RESTR))
+
+@implementer(IConnectionHintHandler)
+class _Common:
+    # subclasses must:
+    #  define _connect()
+    #  set self._socks_hostname, self._socks_port
+
+    def __init__(self):
+        self._connected = False
+        self._when_connected = observer.OneShotObserverList()
+
+    def _maybe_connect(self, reactor):
+        if not self._connected:
+            self._connected = True
+            # connect
+            d = self._connect()
+            d.addBoth(self._when_connected.fire)
+        return self._when_connected.whenFired()
+
+    @inlineCallbacks
+    def hint_to_endpoint(self, hint, reactor):
+        # Return (endpoint, hostname), where "hostname" is what we pass to the
+        # HTTP "Host:" header so a dumb HTTP server can be used to redirect us.
+        mo = HINT_RE.search(hint)
+        if not mo:
+            raise InvalidHintError("unrecognized TCP/Tor hint")
+        host, port = mo.group(1), int(mo.group(2))
+        if is_non_public_numeric_address(host):
+            raise InvalidHintError("ignoring non-Tor-able ipaddr %s" % host)
+        yield self._maybe_connect(reactor)
+        # txsocksx doesn't like unicode: it concatenates some binary protocol
+        # bytes with the hostname when talking to the SOCKS server, so the
+        # py2 automatic unicode promotion blows up
+        host = host.encode("ascii")
+        ep = txtorcon.TorClientEndpoint(host, port,
+                                        socks_hostname=self._socks_hostname,
+                                        socks_port=self._socks_port)
+        returnValue( (ep, host) )
+
+
+# note: TorClientEndpoint imports 'reactor' itself, doesn't provide override
+
+class _SocksTor(_Common):
+    def __init__(self, hostname=None, port=None):
+        _Common.__init__(self)
+        self._connnected = True # no need to call _connect()
+        self._socks_hostname = hostname
+        self._socks_port = port # None means to use defaults: 9050, then 9150
+    def _connect(self):
+        return succeed(None)
+
+def default_socks():
+    # TorClientEndpoint knows how to cycle through a built-in set of socks
+    # ports, but it doesn't know to set the hostname to localhost
+    return _SocksTor("127.0.0.1")
+
+def socks_on_port(port):
+    return _SocksTor("127.0.0.1", port)
+
+
+class _LaunchedTor(_Common):
+    def __init__(self, reactor, data_directory=None, tor_binary=None):
+        _Common.__init__(self)
+        self._reactor = reactor
+        self._data_directory = data_directory
+        self._tor_binary = tor_binary
+
+    @inlineCallbacks
+    def _connect(self):
+        # create a new Tor
+        config = self.config = txtorcon.TorConfig()
+        if self._data_directory:
+            # The default is for launch_tor to create a tempdir itself, and
+            # delete it when done. We only need to set a DataDirectory if we
+            # want it to be persistent. This saves some startup time, because
+            # we cache the descriptors from last time. On one of my hosts,
+            # this reduces connect from 20s to 15s.
+            if not os.path.exists(self._data_directory):
+                # tor will mkdir this, but txtorcon wants to chdir to it
+                # before spawning the tor process, so (for now) we need to
+                # mkdir it ourselves. TODO: txtorcon should take
+                # responsibility for this.
+                os.mkdir(self._data_directory)
+            config.DataDirectory = self._data_directory
+
+        #config.ControlPort = allocate_tcp_port() # defaults to 9052
+        config.SocksPort = allocate_tcp_port()
+        self._socks_hostname = "127.0.0.1"
+        self._socks_port = config.SocksPort
+
+        #print "launching tor"
+        tpp = yield txtorcon.launch_tor(config, self._reactor,
+                                        tor_binary=self._tor_binary,
+                                        )
+        #print "launched"
+        # gives a TorProcessProtocol with .tor_protocol
+        self._tor_protocol = tpp.tor_protocol
+        returnValue(True)
+
+def launch_tor(reactor, data_directory=None, tor_binary=None):
+    """Return a handler which launches a new Tor process (once).
+    - data_directory: a persistent directory where Tor can cache its
+      descriptors. This allows subsequent invocations to start faster. If
+      None, the process will use an ephemeral tempdir, deleting it when Tor
+      exits.
+    - tor_binary: the path to the Tor executable we should use. If None,
+      search $PATH.
+    """
+    return _LaunchedTor(reactor, data_directory, tor_binary)
+
+
+@implementer(IConnectionHintHandler)
+class _ConnectedTor(_Common):
+    def __init__(self, reactor, tor_control_endpoint):
+        _Common.__init__(self)
+        self._reactor = reactor
+        assert IStreamClientEndpoint.providedBy(tor_control_endpoint)
+        self._tor_control_endpoint = tor_control_endpoint
+
+    @inlineCallbacks
+    def _connect(self):
+        ep = self._tor_control_endpoint
+        tproto = yield txtorcon.build_tor_connection(ep, build_state=False)
+        config = yield txtorcon.TorConfig.from_protocol(tproto)
+        ports = list(config.SocksPort)
+        port = ports[0]
+        if port == "DEFAULT":
+            port = "9050"
+        port = int(port)
+        self._socks_hostname = "127.0.0.1"
+        self._socks_port = port
+
+
+def with_control_port(reactor, tor_control_endpoint):
+    """Return a handler which connects to a pre-existing Tor process on the
+    given control port.
+    - control_port: a ClientEndpoint which points at the Tor control port
+    """
+    return _ConnectedTor(reactor, tor_control_endpoint)


### PR DESCRIPTION
Adds several connection handlers that can be used to connect to Tor hidden-service hints, or to use Tor to connect to normal TCP hints. For https://foolscap.lothar.com/trac/ticket/246 .

@meejah, could you take a look at this and see what you think? I don't have a way to test it this week, and even if it worked I'm not sure it'd be using txtorcon correctly. But the idea is to be able to set up a tor-hint connection handler with one of three functions, depending upon what your tor setup is:

* `default_socks_handler()` if you think there might be a Tor listening for SOCKS on localhost 9050/9150
* `with_control_port(control_port_endpoint)` if you think Tor is listening for control messages on some known endpoint
* `launch_tor(tor_binary=)` if you want to launch a new Tor (defaulting to searching $PATH)

Connecting to the control port (or launching tor) should only happen once (I could be talked out of this, but I figure that if it fails the first time, then reconnecting/relaunching for every single hint is a waste of time), hence the whole `_when_connection()` thing.

I copied the txtorcon-using code from Magic Wormhole, but I realized that I don't think I really tested the connect-to-pre-existing-control-port path, since it looks kind of incomplete.

I suspect this will take some work before it's ready to land, but I think a PR is the easiest way to let others review it. If/when we get it into shape, I'll rebase/force-push and use this PR to land it.
