### PR TITLE
test_connection: stop using internal Twisted attributes

### DIFF
--- a/src/foolscap/connections/tcp.py
+++ b/src/foolscap/connections/tcp.py
@@ -1,6 +1,6 @@
 import re
 from zope.interface import implementer
-from twisted.internet import endpoints
+from twisted.internet.endpoints import HostnameEndpoint
 from foolscap.ipb import IConnectionHintHandler, InvalidHintError
 
 DOTTED_QUAD_RESTR=r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}"
@@ -63,7 +63,7 @@ class DefaultTCP:
             raise InvalidHintError("unrecognized TCP hint")
         host, port = mo.group(1), int(mo.group(2))
         host = host.lstrip("[").rstrip("]")
-        return endpoints.HostnameEndpoint(reactor, host, port), host
+        return HostnameEndpoint(reactor, host, port), host
 
     def describe(self):
         return "tcp"


### PR DESCRIPTION
This test was checking private attributes of HostnameEndpoint. These were
renamed on Twisted trunk sometime after Twisted-16.6.0, so they'll break the
Foolscap tests once the next Twisted release comes out (probably 17.0.0).

This fixes the tests to use a less fragile approach.