### PR TITLE
247 jsonlogs

### DIFF
--- a/src/foolscap/logging/dumper.py
+++ b/src/foolscap/logging/dumper.py
@@ -1,5 +1,5 @@
 
-import sys, errno
+import sys, errno, textwrap
 from twisted.python import usage
 from foolscap.logging import flogfile
 from foolscap.logging.log import format_message
@@ -47,11 +47,24 @@ class LogDumper:
                 return 1
             raise
         except flogfile.ThisIsActuallyAFurlFileError:
-            print >>options.stderr, (
-                "Error: %s appears to be a FURL file.\n"
-                "Perhaps you meant to run"
-                " 'flogtool tail' instead of 'flogtool dump'?"
+            print >>options.stderr, textwrap.dedent("""\
+                Error: %s appears to be a FURL file.
+                Perhaps you meant to run 'flogtool tail' instead of 'flogtool
+                dump'?"""
                 % (options.dumpfile,))
+            return 1
+        except flogfile.EvilPickleFlogFile:
+            print >>options.stderr, textwrap.dedent("""\
+            Error: %s appears to be an old-style
+            (pickle-based) flogfile, which cannot be loaded safely. If you
+            wish to allow the author of the flogfile to take over your
+            computer, and view the content, please use the flogtool from a
+            copy of foolscap-0.9.2 or earlier.""" % (options.dumpfile,))
+            return 1
+        except flogfile.BadMagic as e:
+            print >>options.stderr, textwrap.dedent("""\
+            Error: %s does not appear to be a flogfile.
+            """ % (options.dumpfile,))
             return 1
         except ValueError, ex:
             print >>options.stderr, (

--- a/src/foolscap/logging/dumper.py
+++ b/src/foolscap/logging/dumper.py
@@ -104,7 +104,11 @@ class LogDumper:
         # let's mark the trigger event from incident reports with
         # [INCIDENT-TRIGGER] at the end of the line
         is_trigger = bool(self.trigger and (eid == self.trigger))
-        text = format_message(d)
+        try:
+            text = format_message(d)
+        except:
+            print "unformattable event", d
+            raise
 
         t = "%s#%d " % (short, d['num'])
         if options['rx-time']:
@@ -121,6 +125,6 @@ class LogDumper:
         print >>stdout, t
         if 'failure' in d:
             print >>stdout," FAILURE:"
-            lines = str(d['failure']).split("\n")
+            lines = str(d['failure'].get('str', d['failure'])).split("\n")
             for line in lines:
                 print >>stdout, " %s" % (line,)

--- a/src/foolscap/logging/dumper.py
+++ b/src/foolscap/logging/dumper.py
@@ -49,8 +49,7 @@ class LogDumper:
         except flogfile.ThisIsActuallyAFurlFileError:
             print >>options.stderr, textwrap.dedent("""\
                 Error: %s appears to be a FURL file.
-                Perhaps you meant to run 'flogtool tail' instead of 'flogtool
-                dump'?"""
+                Perhaps you meant to run 'flogtool tail' instead of 'flogtool dump'?"""
                 % (options.dumpfile,))
             return 1
         except flogfile.EvilPickleFlogFile:

--- a/src/foolscap/logging/dumper.py
+++ b/src/foolscap/logging/dumper.py
@@ -57,8 +57,9 @@ class LogDumper:
             Error: %s appears to be an old-style
             (pickle-based) flogfile, which cannot be loaded safely. If you
             wish to allow the author of the flogfile to take over your
-            computer, and view the content, please use the flogtool from a
-            copy of foolscap-0.9.2 or earlier.""" % (options.dumpfile,))
+            computer (and incidentally allow you to view the content), please
+            use the flogtool from a copy of foolscap-0.12.7 or earlier."""
+                                                    % (options.dumpfile,))
             return 1
         except flogfile.BadMagic as e:
             print >>options.stderr, textwrap.dedent("""\

--- a/src/foolscap/logging/filter.py
+++ b/src/foolscap/logging/filter.py
@@ -61,6 +61,7 @@ class Filter:
             newfile = bz2.BZ2File(newfilename, "w")
         else:
             newfile = open(newfilename, "wb")
+        newfile.write(flogfile.MAGIC)
         after = options['after']
         if after is not None:
             print >>stdout, " --after: removing events before %s" % time.ctime(after)

--- a/src/foolscap/logging/flogfile.py
+++ b/src/foolscap/logging/flogfile.py
@@ -1,5 +1,6 @@
 import json
 from contextlib import closing
+from twisted.python import failure
 
 class JSONableFailure:
     def __init__(self, f):
@@ -7,13 +8,16 @@ class JSONableFailure:
 
 class ExtendedEncoder(json.JSONEncoder):
     def default(self, o):
-        if isinstance(o, JSONableFailure):
+        if isinstance(o, failure.Failure):
+            # this includes CopyableFailure
+            #
             # pickled Failures get the following modified attributes: frames,
             # tb=None, stack=, pickled=1
             return {"@": "Failure",
-                    "repr": repr(o.f),
-                    "traceback": o.f.getTraceback(),
-                    # o.f.frames? .stack? .type?
+                    "str": str(o),
+                    "repr": repr(o),
+                    "traceback": o.getTraceback(),
+                    # o.frames? .stack? .type?
                     }
         return json.JSONEncoder.default(self, o)
 

--- a/src/foolscap/logging/flogfile.py
+++ b/src/foolscap/logging/flogfile.py
@@ -1,28 +1,53 @@
-import pickle
+import json
 from contextlib import closing
 
+class JSONableFailure:
+    def __init__(self, f):
+        self.f = f
+
+class ExtendedEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, JSONableFailure):
+            # pickled Failures get the following modified attributes: frames,
+            # tb=None, stack=, pickled=1
+            return {"@": "Failure",
+                    "repr": repr(o.f),
+                    "traceback": o.f.getTraceback(),
+                    # o.f.frames? .stack? .type?
+                    }
+        return json.JSONEncoder.default(self, o)
+
 def serialize_raw_header(f, header):
-    pickle.dump({"header": header}, f)
+    json.dump({"header": header}, f, cls=ExtendedEncoder)
+    f.write("\n")
 
 def serialize_header(f, type, **kwargs):
     header = {"header": {"type": type} }
     for k,v in kwargs.items():
         header["header"][k] = v
-    pickle.dump(header, f)
+    json.dump(header, f, cls=ExtendedEncoder)
+    f.write("\n")
 
 def serialize_raw_wrapper(f, wrapper):
-    pickle.dump(wrapper, f)
+    json.dump(wrapper, f, cls=ExtendedEncoder)
+    f.write("\n")
 
 def serialize_wrapper(f, ev, from_, rx_time):
     wrapper = {"from": from_,
                "rx_time": rx_time,
                "d": ev}
-    pickle.dump(wrapper, f)
+    json.dump(wrapper, f, cls=ExtendedEncoder)
+    f.write("\n")
 
-class ThisIsActuallyAFurlFileError(Exception):
+MAGIC = "# foolscap flogfile v1\n"
+class BadMagic(Exception):
+    """The file is not a flogfile: wrong magic number."""
+class EvilPickleFlogFile(BadMagic):
+    """This is an old (pickle-based) flogfile, and cannot be loaded safely."""
+class ThisIsActuallyAFurlFileError(BadMagic):
     pass
 
-def get_events(fn, ignore_value_error=False):
+def get_events(fn):
     if fn.endswith(".bz2"):
         import bz2
         f = bz2.BZ2File(fn, "r")
@@ -31,21 +56,15 @@ def get_events(fn, ignore_value_error=False):
         f = open(fn, "rb")
 
     with closing(f):
-        while True:
-            try:
-                e = pickle.load(f)
-                yield e
-            except EOFError:
-                break
-            except ValueError:
-                if ignore_value_error:
-                    break
-                raise
-            except IndexError:
-                # this happens when you point "flogtool dump" at a furl by
-                # mistake (which cannot be parsed as a pickle). Emit a useful
-                # error message.
-                f.seek(0)
-                if f.read(3) == "pb:":
-                    raise ThisIsActuallyAFurlFileError
-
+        maybe_magic = f.read(len(MAGIC))
+        if maybe_magic != MAGIC:
+            if maybe_magic.startswith("(dp0"):
+                raise EvilPickleFlogFile()
+            if maybe_magic.startswith("pb:"):
+                # this happens when you point "flogtool dump" at a furlfile
+                # (e.g. logport.furl) by mistake. Emit a useful error
+                # message.
+                raise ThisIsActuallyAFurlFileError
+            raise BadMagic(repr(maybe_magic))
+        for line in f.readlines():
+            yield json.loads(line)

--- a/src/foolscap/logging/gatherer.py
+++ b/src/foolscap/logging/gatherer.py
@@ -406,6 +406,7 @@ class IncidentObserver(Referenceable):
         now = time.time()
         (header, events) = incident
         f = bz2.BZ2File(filename, "w")
+        f.write(flogfile.MAGIC)
         flogfile.serialize_raw_header(f, header)
         for e in events:
             flogfile.serialize_wrapper(f, e, from_=self.tubid_s, rx_time=now)

--- a/src/foolscap/logging/gatherer.py
+++ b/src/foolscap/logging/gatherer.py
@@ -188,6 +188,7 @@ class GathererService(GatheringBase):
         new_filename = "from-%s---to-present.flog" % self.format_time(now)
         self._savefile_name = os.path.join(self.basedir, new_filename)
         self._savefile = open(self._savefile_name, "ab", 0)
+        self._savefile.write(flogfile.MAGIC)
         self._starting_timestamp = now
         flogfile.serialize_header(self._savefile, "gatherer",
                                   start=self._starting_timestamp)

--- a/src/foolscap/logging/incident.py
+++ b/src/foolscap/logging/incident.py
@@ -40,10 +40,10 @@ class IncidentQualifier:
 class IncidentReporter:
     """Once an Incident has been declared, I am responsible for making a
     durable record all relevant log events. I do this by creating a logfile
-    (a pickle of log event dictionaries) and copying everything from the
-    history buffer into it. I can copy a small number of future events into
-    it as well, to record what happens as the application copes with the
-    situtation.
+    (a series of JSON lines, one per log event dictionary) and copying
+    everything from the history buffer into it. I can copy a small number of
+    future events into it as well, to record what happens as the application
+    copes with the situtation.
 
     I am responsible for just a single incident.
 
@@ -89,6 +89,8 @@ class IncidentReporter:
         self.f2 = bz2.BZ2File(self.abs_filename_bz2_tmp, "wb")
 
         # write header with triggering_event
+        self.f1.write(flogfile.MAGIC)
+        self.f2.write(flogfile.MAGIC)
         flogfile.serialize_header(self.f1, "incident",
                                   trigger=triggering_event,
                                   versions=app_versions.versions,
@@ -210,7 +212,7 @@ class IncidentClassifierBase:
 
     def load_incident(self, abs_fn):
         assert abs_fn.endswith(".bz2")
-        events = flogfile.get_events(abs_fn, ignore_value_error=True)
+        events = flogfile.get_events(abs_fn)
         header = next(events)["header"]
         wrapped_events = [event["d"] for event in events]
         return (header, wrapped_events)

--- a/src/foolscap/logging/log.py
+++ b/src/foolscap/logging/log.py
@@ -212,15 +212,6 @@ class FoolscapLogger:
         if "time" not in event:
             event['time'] = time.time()
 
-        if "failure" in event:
-            # we need to avoid pickling the exception class, since that will
-            # require the original application code to unpickle, and log
-            # viewers may not have it installed. A CopiedFailure works great
-            # for this purpose. TODO: I'd prefer to not use a local import
-            # here, but doing at the top level causes a circular import
-            # failure.
-            event["failure"] = flogfile.JSONableFailure(event["failure"])
-
         if event.get('stacktrace', False) is True:
             event['stacktrace'] = traceback.format_stack()
         event['incarnation'] = self.incarnation

--- a/src/foolscap/logging/publish.py
+++ b/src/foolscap/logging/publish.py
@@ -230,7 +230,7 @@ class LogPublisher(Referenceable):
             fn = abs_fn + ".bz2"
             if not os.path.exists(fn):
                 fn = abs_fn
-            events = flogfile.get_events(fn, ignore_value_error=True)
+            events = flogfile.get_events(fn)
             # note the generator isn't actually cycled yet, not until next()
             header = next(events)["header"]
         except EnvironmentError:

--- a/src/foolscap/logging/publish.py
+++ b/src/foolscap/logging/publish.py
@@ -110,7 +110,8 @@ class IncidentSubscription(Referenceable):
             fn = new[name]
             trigger = self.publisher.get_incident_trigger(fn)
             if trigger:
-                self.observer.callRemoteOnly("new_incident", name, trigger)
+                self.observer.callRemoteOnly("new_incident", name,
+                                             _keys_to_bytes(trigger))
         self.observer.callRemoteOnly("done_with_incident_catchup")
 
     def unsubscribe(self):
@@ -129,6 +130,15 @@ class IncidentSubscription(Referenceable):
         print "INCIDENT PUBLISH FAILED: %s" % f
         self.unsubscribe()
 
+
+def _keys_to_bytes(d):
+    # the interfaces.Header and Event schema require the keys to be bytes
+    # ("str", since we're in py2), but we get unicode since we're pulling
+    # from a JSON-serialized incident file. These keys are fixed strings
+    # like (message, level, facility, from, rx_time, d). Encode to ASCII to
+    # make this clear. The user-provided data lives in the *values* of
+    # these dicts, which are unconstrained (the schemas use Any())
+    return dict([ (k.encode("ascii"), v) for (k,v) in d.iteritems()])
 
 class LogPublisher(Referenceable):
     """Publish log events to anyone subscribed to our 'logport'.
@@ -218,7 +228,7 @@ class LogPublisher(Referenceable):
         for (name,fn) in self.list_incident_names(since):
             trigger = self.get_incident_trigger(fn)
             if trigger:
-                incidents[name] = trigger
+                incidents[name] = _keys_to_bytes(trigger)
         return incidents
 
     def remote_get_incident(self, name):
@@ -232,10 +242,10 @@ class LogPublisher(Referenceable):
                 fn = abs_fn
             events = flogfile.get_events(fn)
             # note the generator isn't actually cycled yet, not until next()
-            header = next(events)["header"]
+            header = _keys_to_bytes(next(events)["header"])
         except EnvironmentError:
             raise KeyError("no incident named %s" % name)
-        wrapped_events = [event["d"] for event in events]
+        wrapped_events = [_keys_to_bytes(event["d"]) for event in events]
         return (header, wrapped_events)
 
     def remote_subscribe_to_incidents(self, observer, catch_up=False, since=""):

--- a/src/foolscap/logging/tail.py
+++ b/src/foolscap/logging/tail.py
@@ -18,6 +18,7 @@ class LogSaver(Referenceable):
     def __init__(self, nodeid_s, savefile):
         self.nodeid_s = nodeid_s
         self.f = savefile # we own this, and may close it
+        self.f.write(flogfile.MAGIC)
 
     def emit_header(self, versions, pid):
         flogfile.serialize_header(self.f, "tail", versions=versions, pid=pid)

--- a/src/foolscap/pb.py
+++ b/src/foolscap/pb.py
@@ -215,12 +215,12 @@ class Tub(service.MultiService):
         self.tubID = crypto.digest32(cert.digest("sha1"))
 
     def make_incarnation(self):
-        unique = os.urandom(8)
+        unique = binascii.b2a_hex(os.urandom(8))
         # TODO: it'd be nice to have a sequential component, so incarnations
         # could be ordered, but it requires disk space
         sequential = None
         self.incarnation = (unique, sequential)
-        self.incarnation_string = binascii.b2a_hex(unique)
+        self.incarnation_string = unique
 
     def getIncarnationString(self):
         return self.incarnation_string

--- a/src/foolscap/test/test_copyable.py
+++ b/src/foolscap/test/test_copyable.py
@@ -1,5 +1,4 @@
 
-import pickle
 from twisted.trial import unittest
 from twisted.python import components, failure, reflect
 from foolscap.test.common import TargetMixin, HelperTarget
@@ -133,18 +132,20 @@ class Copyable(TargetMixin, unittest.TestCase):
         # there should be a traceback
         self.failUnless(f.traceback.find("raise RuntimeError") != -1,
                         "no 'raise RuntimeError' in '%s'" % (f.traceback,))
-        # we should be able to pickle CopiedFailures, and when we restore
-        # them, they should look like the original
-        p = pickle.dumps(f)
-        f2 = pickle.loads(p)
-        self.failUnlessEqual(reflect.qual(f2.type), "exceptions.RuntimeError")
-        self.failUnless(f2.check, RuntimeError)
-        self.failUnlessEqual(f2.value, "message here")
-        self.failUnlessEqual(f2.frames, [])
-        self.failUnlessEqual(f2.tb, None)
-        self.failUnlessEqual(f2.stack, [])
-        self.failUnless(f2.traceback.find("raise RuntimeError") != -1,
-                        "no 'raise RuntimeError' in '%s'" % (f2.traceback,))
+        # older Twisted (before 17.9.0) used a Failure class that could be
+        # pickled, so our derived CopiedFailure class could be round-tripped
+        # through pickle correclty. Twisted-17.9.0 changed that, so we no
+        # longer try that.
+        ## p = pickle.dumps(f)
+        ## f2 = pickle.loads(p)
+        ## self.failUnlessEqual(reflect.qual(f2.type), "exceptions.RuntimeError")
+        ## self.failUnless(f2.check, RuntimeError)
+        ## self.failUnlessEqual(f2.value, "message here")
+        ## self.failUnlessEqual(f2.frames, [])
+        ## self.failUnlessEqual(f2.tb, None)
+        ## self.failUnlessEqual(f2.stack, [])
+        ## self.failUnless(f2.traceback.find("raise RuntimeError") != -1,
+        ##                 "no 'raise RuntimeError' in '%s'" % (f2.traceback,))
 
     def testFailure2(self):
         self.callingBroker.unsafeTracebacks = False
@@ -167,17 +168,17 @@ class Copyable(TargetMixin, unittest.TestCase):
         # there should not be a traceback
         self.failUnlessEqual(f.traceback, "Traceback unavailable\n")
 
-        # we should be able to pickle CopiedFailures, and when we restore
-        # them, they should look like the original
-        p = pickle.dumps(f)
-        f2 = pickle.loads(p)
-        self.failUnlessEqual(reflect.qual(f2.type), "exceptions.RuntimeError")
-        self.failUnless(f2.check, RuntimeError)
-        self.failUnlessEqual(f2.value, "message here")
-        self.failUnlessEqual(f2.frames, [])
-        self.failUnlessEqual(f2.tb, None)
-        self.failUnlessEqual(f2.stack, [])
-        self.failUnlessEqual(f2.traceback, "Traceback unavailable\n")
+        ## # we should be able to pickle CopiedFailures, and when we restore
+        ## # them, they should look like the original
+        ## p = pickle.dumps(f)
+        ## f2 = pickle.loads(p)
+        ## self.failUnlessEqual(reflect.qual(f2.type), "exceptions.RuntimeError")
+        ## self.failUnless(f2.check, RuntimeError)
+        ## self.failUnlessEqual(f2.value, "message here")
+        ## self.failUnlessEqual(f2.frames, [])
+        ## self.failUnlessEqual(f2.tb, None)
+        ## self.failUnlessEqual(f2.stack, [])
+        ## self.failUnlessEqual(f2.traceback, "Traceback unavailable\n")
 
     def testCopy1(self):
         obj = MyCopyable1() # just copies the dict

--- a/src/foolscap/test/test_logging.py
+++ b/src/foolscap/test/test_logging.py
@@ -1,5 +1,5 @@
 
-import os, sys, pickle, time, bz2
+import os, sys, pickle, time, bz2, base64
 from cStringIO import StringIO
 from zope.interface import implements
 from twisted.trial import unittest
@@ -2006,6 +2006,85 @@ class Dumper(unittest.TestCase, LogfileWriterMixin, LogfileReaderMixin):
         argv = ["flogtool", "dump", fn]
         (out,err) = cli.run_flogtool(argv[1:], run_by_human=False)
         self.failUnlessEqual(err, "Error: %s appears to be a FURL file.\nPerhaps you meant to run 'flogtool tail' instead of 'flogtool dump'?\n" % fn)
+
+PICKLE_DUMPFILE_B64 = """
+KGRwMApTJ2hlYWRlcicKcDEKKGRwMgpTJ3RocmVzaG9sZCcKcDMKSTAKc1MncGlkJwpwNA
+pJMTg3MjgKc1MndHlwZScKcDUKUydsb2ctZmlsZS1vYnNlcnZlcicKcDYKc1MndmVyc2lv
+bnMnCnA3CihkcDgKUydmb29sc2NhcCcKcDkKUycwLjkuMSsyMi5nNzhlNWEzZC5kaXJ0eS
+cKcDEwCnNTJ3R3aXN0ZWQnCnAxMQpTJzE1LjUuMCcKcDEyCnNzcy6AAn1xAChVBGZyb21x
+AVUFbG9jYWxxAlUHcnhfdGltZXEDR0HVmqGrUXpjVQFkcQR9cQUoVQVsZXZlbHEGSxRVC2
+luY2FybmF0aW9ucQdVCMZQLsaodzvDcQhOhnEJVQhmYWNpbGl0eXEKVQxiaWcuZmFjaWxp
+dHlxC1UDbnVtcQxLAFUEdGltZXENR0HVmqGrRFtbVQdtZXNzYWdlcQ5VA29uZXEPdXUugA
+J9cQAoVQRmcm9tcQFVBWxvY2FscQJVB3J4X3RpbWVxA0dB1Zqhq1F+s1UBZHEEfXEFKFUH
+bWVzc2FnZXEGVQN0d29xB1UDbnVtcQhLAVUEdGltZXEJR0HVmqGrUU6cVQtpbmNhcm5hdG
+lvbnEKVQjGUC7GqHc7w3ELToZxDFUFbGV2ZWxxDUsTdXUugAJ9cQAoVQRmcm9tcQFVBWxv
+Y2FscQJVB3J4X3RpbWVxA0dB1Zqhq1GAiFUBZHEEfXEFKFUFbGV2ZWxxBksUVQtpbmNhcm
+5hdGlvbnEHVQjGUC7GqHc7w3EIToZxCVUDd2h5cQpOVQdmYWlsdXJlcQsoY2Zvb2xzY2Fw
+LmNhbGwKQ29waWVkRmFpbHVyZQpxDG9xDX1xDyhVAnRicRBOVQl0cmFjZWJhY2txEVSBAw
+AAVHJhY2ViYWNrIChtb3N0IHJlY2VudCBjYWxsIGxhc3QpOgogIEZpbGUgIi9Vc2Vycy93
+YXJuZXIvc3R1ZmYvcHl0aG9uL2Zvb2xzY2FwL3ZlL2xpYi9weXRob24yLjcvc2l0ZS1wYW
+NrYWdlcy90d2lzdGVkL3RyaWFsL19hc3luY3Rlc3QucHkiLCBsaW5lIDExMiwgaW4gX3J1
+bgogICAgdXRpbHMucnVuV2l0aFdhcm5pbmdzU3VwcHJlc3NlZCwgc2VsZi5fZ2V0U3VwcH
+Jlc3MoKSwgbWV0aG9kKQogIEZpbGUgIi9Vc2Vycy93YXJuZXIvc3R1ZmYvcHl0aG9uL2Zv
+b2xzY2FwL3ZlL2xpYi9weXRob24yLjcvc2l0ZS1wYWNrYWdlcy90d2lzdGVkL2ludGVybm
+V0L2RlZmVyLnB5IiwgbGluZSAxNTAsIGluIG1heWJlRGVmZXJyZWQKICAgIHJlc3VsdCA9
+IGYoKmFyZ3MsICoqa3cpCiAgRmlsZSAiL1VzZXJzL3dhcm5lci9zdHVmZi9weXRob24vZm
+9vbHNjYXAvdmUvbGliL3B5dGhvbjIuNy9zaXRlLXBhY2thZ2VzL3R3aXN0ZWQvaW50ZXJu
+ZXQvdXRpbHMucHkiLCBsaW5lIDE5NywgaW4gcnVuV2l0aFdhcm5pbmdzU3VwcHJlc3NlZA
+ogICAgcmVzdWx0ID0gZigqYSwgKiprdykKICBGaWxlICIvVXNlcnMvd2FybmVyL3N0dWZm
+L3B5dGhvbi9mb29sc2NhcC9mb29sc2NhcC90ZXN0L3Rlc3RfbG9nZ2luZy5weSIsIGxpbm
+UgMTg4MywgaW4gdGVzdF9kdW1wCiAgICBkID0gc2VsZi5jcmVhdGVfbG9nZmlsZSgpCi0t
+LSA8ZXhjZXB0aW9uIGNhdWdodCBoZXJlPiAtLS0KICBGaWxlICIvVXNlcnMvd2FybmVyL3
+N0dWZmL3B5dGhvbi9mb29sc2NhcC9mb29sc2NhcC90ZXN0L3Rlc3RfbG9nZ2luZy5weSIs
+IGxpbmUgMTg0MiwgaW4gY3JlYXRlX2xvZ2ZpbGUKICAgIHJhaXNlIFNhbXBsZUVycm9yKC
+J3aG9vcHMxIikKZm9vbHNjYXAudGVzdC50ZXN0X2xvZ2dpbmcuU2FtcGxlRXJyb3I6IHdo
+b29wczEKcRJVBXZhbHVlcRNVB3dob29wczFxFFUHcGFyZW50c3EVXXEWKFUmZm9vbHNjYX
+AudGVzdC50ZXN0X2xvZ2dpbmcuU2FtcGxlRXJyb3JxF1UUZXhjZXB0aW9ucy5FeGNlcHRp
+b25xGFUYZXhjZXB0aW9ucy5CYXNlRXhjZXB0aW9ucRlVEl9fYnVpbHRpbl9fLm9iamVjdH
+EaZVUGZnJhbWVzcRtdcRxVBHR5cGVxHVUmZm9vbHNjYXAudGVzdC50ZXN0X2xvZ2dpbmcu
+U2FtcGxlRXJyb3JxHlUFc3RhY2txH11xIHViVQNudW1xIUsCVQR0aW1lcSJHQdWaoatRVt
+JVB21lc3NhZ2VxI1UFdGhyZWVxJFUHaXNFcnJvcnElSwF1dS6AAn1xAChVBGZyb21xAVUF
+bG9jYWxxAlUHcnhfdGltZXEDR0HVmqGrUYXkVQFkcQR9cQUoVQdtZXNzYWdlcQZVBGZvdX
+JxB1UDbnVtcQhLA1UEdGltZXEJR0HVmqGrUXU2VQtpbmNhcm5hdGlvbnEKVQjGUC7GqHc7
+w3ELToZxDFUFbGV2ZWxxDUsUdXUu
+"""
+
+PICKLE_INCIDENT_B64 = """
+QlpoOTFBWSZTWUOW3hEAAHjfgAAQAcl/4QkhCAS/59/iQAGdWS2BJRTNNQ2oB6gGgPU9T1
+BoEkintKGIABiAAaAwANGhowjJoNGmgMCpJDSaNGqbSMnqGhoaAP1S5rw5GxrNlUoxLXu2
+sZ5TYy2rVCVNHMKgeDE97TBiw1hXtCfdSCISDpSlL61KFiacqWj9apY80J2PIpO7mde+vd
+Jz18Myu4+djYU10JPMGU5vFAcUmmyk0kmcGUSMIDUJcKkog4W2EyyQStwwSYUEohGpr6Wm
+F4KU7qccsjPJf8dTIv3ydZM5hpkW41JjJ8j0PETxlRRVFSeZYsqFU+hufU3n5O3hmYASDC
+DhWMHFPJE7nXCYRsz5BGjktwUQCu6d4cixrgmGYLYA7JVCM7UqkMDVD9EMaclrFuayYGBR
+xMIwXxM9pjeUuZVv2ceR5E6FSWpVRKKD98ObK5wmGmU9vqNBKqjp0wwqZlZ3x3nA4n+LTS
+rmhbVjNyWeh/xdyRThQkEOW3hE
+"""
+
+class OldPickleDumper(unittest.TestCase):
+    def test_dump(self):
+        self.basedir = "logging/OldPickleDumper/dump"
+        if not os.path.exists(self.basedir):
+            os.makedirs(self.basedir)
+        fn = os.path.join(self.basedir, "dump.flog")
+        with open(fn, "wb") as f:
+            f.write(base64.b64decode(PICKLE_DUMPFILE_B64))
+
+        argv = ["flogtool", "dump", fn]
+        (out,err) = cli.run_flogtool(argv[1:], run_by_human=False)
+        self.failUnlessEqual(err, "")
+
+    def test_incident(self):
+        self.basedir = "logging/OldPickleDumper/incident"
+        if not os.path.exists(self.basedir):
+            os.makedirs(self.basedir)
+        fn = os.path.join(self.basedir,
+                          "incident-2015-12-11--08-18-28Z-uqyuiea.flog.bz2")
+        with open(fn, "wb") as f:
+            f.write(base64.b64decode(PICKLE_INCIDENT_B64))
+
+        argv = ["flogtool", "dump", fn]
+        (out,err) = cli.run_flogtool(argv[1:], run_by_human=False)
+        self.failUnlessEqual(err, "")
 
 class Filter(unittest.TestCase, LogfileWriterMixin, LogfileReaderMixin):
 

--- a/src/foolscap/test/test_logging.py
+++ b/src/foolscap/test/test_logging.py
@@ -1955,9 +1955,13 @@ class Dumper(unittest.TestCase, LogfileWriterMixin, LogfileReaderMixin):
             line0 = "local#%d %s: one" % (events[1]["d"]["num"],
                                           format_time(events[1]["d"]["time"],
                                                       tmode))
+            print "----"
+            for l in lines: print "-", l,
+            print "----"
             self.failUnlessEqual(lines[0].strip(), line0)
             self.failUnless("FAILURE:" in lines[3])
-            self.failUnless("test_logging.SampleError: whoops1" in lines[-3])
+            self.failUnlessIn("test_logging.SampleError", lines[4])
+            self.failUnlessIn(": whoops1", lines[4])
             self.failUnless(lines[-1].startswith("local#3 "))
 
             argv = ["flogtool", "dump", "--just-numbers", fn]
@@ -1992,6 +1996,7 @@ class Dumper(unittest.TestCase, LogfileWriterMixin, LogfileReaderMixin):
             (out,err) = cli.run_flogtool(argv[1:], run_by_human=False)
             self.failUnlessEqual(err, "")
             lines = list(StringIO(out).readlines())
+            print lines
             self.failUnless("header" in lines[0])
             self.failUnless("'message': 'one'" in lines[1])
             self.failUnless("'level': 20" in lines[1])

--- a/src/foolscap/test/test_logging.py
+++ b/src/foolscap/test/test_logging.py
@@ -513,11 +513,11 @@ class Incidents(unittest.TestCase, PollMixin, LogfileReaderMixin):
             options.stdout = StringIO()
             ic2.run(options)
             out = options.stdout.getvalue()
-            self.failUnless(".flog.bz2: unknown\n" in out, out)
+            self.failUnlessIn(".flog.bz2: unknown\n", out)
             # this should have a pprinted trigger dictionary
-            self.failUnless("'message': 'foom'," in out, out)
-            self.failUnless("'num': 0," in out, out)
-            self.failUnless("RuntimeError" in out, out)
+            self.failUnless(re.search(r"u?'message': u?'foom',", out), out)
+            self.failUnlessIn("'num': 0,", out)
+            self.failUnlessIn("RuntimeError", out)
 
         d.addCallback(_check)
         return d

--- a/src/foolscap/test/test_logging.py
+++ b/src/foolscap/test/test_logging.py
@@ -1955,9 +1955,6 @@ class Dumper(unittest.TestCase, LogfileWriterMixin, LogfileReaderMixin):
             line0 = "local#%d %s: one" % (events[1]["d"]["num"],
                                           format_time(events[1]["d"]["time"],
                                                       tmode))
-            print "----"
-            for l in lines: print "-", l,
-            print "----"
             self.failUnlessEqual(lines[0].strip(), line0)
             self.failUnless("FAILURE:" in lines[3])
             self.failUnlessIn("test_logging.SampleError", lines[4])
@@ -1996,7 +1993,6 @@ class Dumper(unittest.TestCase, LogfileWriterMixin, LogfileReaderMixin):
             (out,err) = cli.run_flogtool(argv[1:], run_by_human=False)
             self.failUnlessEqual(err, "")
             lines = list(StringIO(out).readlines())
-            print lines
             self.failUnless("header" in lines[0])
             self.failUnless("'message': 'one'" in lines[1])
             self.failUnless("'level': 20" in lines[1])

--- a/src/foolscap/test/test_logging.py
+++ b/src/foolscap/test/test_logging.py
@@ -2251,6 +2251,9 @@ def getPage(url):
         # with a transport that does not have an abortConnection method")
         # which seems to be https://twistedmatrix.com/trac/ticket/8227
         page = yield client.readBody(response)
+    if response.code != 200:
+        raise ValueError("request failed (%d), page contents were: %s" % (
+            response.code, page))
     returnValue(page)
 
 class Web(unittest.TestCase):

--- a/src/foolscap/test/test_logging.py
+++ b/src/foolscap/test/test_logging.py
@@ -1,5 +1,5 @@
 
-import os, sys, json, time, bz2, base64
+import os, sys, json, time, bz2, base64, re
 from cStringIO import StringIO
 from zope.interface import implements
 from twisted.trial import unittest
@@ -1994,7 +1994,7 @@ class Dumper(unittest.TestCase, LogfileWriterMixin, LogfileReaderMixin):
             self.failUnlessEqual(err, "")
             lines = list(StringIO(out).readlines())
             self.failUnless("header" in lines[0])
-            self.failUnless("'message': 'one'" in lines[1])
+            self.failUnless(re.search(r"u?'message': u?'one'", lines[1]), lines[1])
             self.failUnless("'level': 20" in lines[1])
             self.failUnless(": four: {" in lines[-1])
 

--- a/src/foolscap/test/test_logging.py
+++ b/src/foolscap/test/test_logging.py
@@ -1373,8 +1373,8 @@ class Gatherer(unittest.TestCase, LogfileReaderMixin, StallMixin, PollMixin):
         self.failUnlessEqual(data['d']['message'], "")
         self.failUnless(data['d']["isError"])
         self.failUnless("failure" in data['d'])
-        self.failUnless(data['d']["failure"].check(SampleError))
-        self.failUnless("whoops1" in str(data['d']["failure"]))
+        self.failUnlessIn("SampleError", data['d']["failure"]["repr"])
+        self.failUnlessIn("whoops1", data['d']["failure"]["repr"])
 
         # grab the third event from the log
         data = events.pop(0)
@@ -1383,8 +1383,8 @@ class Gatherer(unittest.TestCase, LogfileReaderMixin, StallMixin, PollMixin):
         self.failUnlessEqual(data['d']['message'], "")
         self.failUnless(data['d']["isError"])
         self.failUnless("failure" in data['d'])
-        self.failUnless(data['d']["failure"].check(SampleError))
-        self.failUnless("whoops2" in str(data['d']["failure"]))
+        self.failUnlessIn("SampleError", data['d']["failure"]["repr"])
+        self.failUnlessIn("whoops2", data['d']["failure"]["repr"])
 
     def test_wrongdir(self):
         basedir = "logging/Gatherer/wrongdir"

--- a/src/foolscap/test/test_logging.py
+++ b/src/foolscap/test/test_logging.py
@@ -2129,27 +2129,12 @@ class OldPickleDumper(unittest.TestCase):
 class Filter(unittest.TestCase, LogfileWriterMixin, LogfileReaderMixin):
 
     def compare_events(self, a, b):
-        # cmp(a,b) won't quite work, because two instances of CopiedFailure
-        # loaded from the same pickle don't compare as equal
-        self.failUnlessEqual(len(a), len(b))
-        for i in range(len(a)):
-            a1,b1 = a[i],b[i]
-            self.failUnlessEqual(set(a1.keys()), set(b1.keys()))
-            for k in a1:
-                if k == "d":
-                    self.failUnlessEqual(set(a1["d"].keys()),
-                                         set(b1["d"].keys()))
-                    for k2 in a1["d"]:
-                        if k2 == "failure":
-                            f1 = a1["d"][k2]
-                            f2 = b1["d"][k2]
-                            self.failUnlessEqual(f1.value, f2.value)
-                            self.failUnlessEqual(f1.getTraceback(),
-                                                 f2.getTraceback())
-                        else:
-                            self.failUnlessEqual(a1["d"][k2], b1["d"][k2])
-                else:
-                    self.failUnlessEqual(a1[k], b1[k])
+        ## # cmp(a,b) won't quite work, because two instances of CopiedFailure
+        ## # loaded from the same pickle don't compare as equal
+
+        # in fact we no longer create CopiedFailure instances in logs, so a
+        # simple failUnlessEqual will now suffice
+        self.failUnlessEqual(a, b)
 
 
     def test_basic(self):

--- a/src/foolscap/test/test_pb.py
+++ b/src/foolscap/test/test_pb.py
@@ -465,11 +465,9 @@ class TestCallable(MakeTubsMixin, unittest.TestCase):
             self.failUnlessEqual(len(failures), 1)
             f = failures[0]
             self.failUnless(isinstance(f, failure.Failure))
-            self.failUnless(isinstance(f, call.CopiedFailure))
-            self.failUnless("Traceback (most recent call last):\n"
-                            in str(f))
-            self.failUnless("\nexceptions.ValueError: you asked me to fail\n"
-                            in str(f))
+            self.failUnlessIn("Traceback:", str(f))
+            self.failUnlessIn("exceptions.ValueError", str(f))
+            self.failUnlessIn(": you asked me to fail\n", str(f))
         d.addBoth(_check)
         return d
     testLogLocalFailure.timeout = 2


### PR DESCRIPTION
rewrite log-event serialization (Incident files, gatherer output files) to use JSON instead of pickle
