### PR TITLE
Py3k port - Initial PR

### DIFF
--- a/src/foolscap/banana.py
+++ b/src/foolscap/banana.py
@@ -24,7 +24,8 @@ if six.PY3:
     long = int
 
 def ensure_byte(ch):
-    # PY3PORT - new function
+    """ Convert an integer to a byte in a 2/3 portable way """
+    
     if six.PY2:
         return ch
     elif six.PY3:
@@ -32,15 +33,13 @@ def ensure_byte(ch):
 
 def int2b128(integer, stream):
     if integer == 0:
-        # PY3KPORT
         stream(six.int2byte(0))
         return
     assert integer > 0, "can only encode positive integers"
     while integer:
-        # PY3KPORT      
         stream(six.int2byte(integer & 0x7f))
         integer = integer >> 7
-        
+
 def b1282int(st):
     # NOTE that this is little-endian
     oneHundredAndTwentyEight = 128
@@ -50,7 +49,6 @@ def b1282int(st):
         try:
             num = ord(char)
         except TypeError:
-            # PY3KPORT          
             num = ord(six.int2byte(char))       
         i = i + (num * (oneHundredAndTwentyEight ** place))
         place = place + 1
@@ -194,7 +192,6 @@ class Banana(protocol.Protocol):
 
         itr = self.rootSlicer.slice()
 
-        # PY3KPORT
         try:
             next = iter(itr).__next__
         except Exception:
@@ -366,7 +363,6 @@ class Banana(protocol.Protocol):
 
         itr = slicer.slice(topSlicer.streamable, self)
 
-        # PY3KPORT
         try:
             next = iter(itr).__next__
         except Exception:
@@ -541,7 +537,6 @@ class Banana(protocol.Protocol):
                 self.maybeVocabizeString(obj)
                 int2b128(len(obj), write)
                 write(STRING)
-                # PY3KPORT - A bit unsure about this
                 write(six.ensure_binary(obj))
         else:
             raise BananaError("could not send object: %s" % repr(obj))
@@ -777,7 +772,6 @@ class Banana(protocol.Protocol):
             # At this point, the header and type byte have been received.
             # The body may or may not be complete.
 
-            # PY3KPORT
             typebyte = ensure_byte(first65[pos])
                 
             if pos:

--- a/src/foolscap/banana.py
+++ b/src/foolscap/banana.py
@@ -23,6 +23,13 @@ EPSILON = 0.1
 if six.PY3:
     long = int
 
+def ensure_byte(ch):
+    # PY3PORT - new function
+    if six.PY2:
+        return ch
+    elif six.PY3:
+        return six.int2byte(ch)
+
 def int2b128(integer, stream):
     if integer == 0:
         # PY3KPORT
@@ -534,7 +541,8 @@ class Banana(protocol.Protocol):
                 self.maybeVocabizeString(obj)
                 int2b128(len(obj), write)
                 write(STRING)
-                write(obj)
+                # PY3KPORT - A bit unsure about this
+                write(six.ensure_binary(obj))
         else:
             raise BananaError("could not send object: %s" % repr(obj))
 
@@ -748,6 +756,7 @@ class Banana(protocol.Protocol):
             first65 = self.buffer.popleft(65)
             pos = 0
             for ch in first65:
+                ch = ensure_byte(ch)                
                 if ch >= HIGH_BIT_SET:
                     break
                 pos = pos + 1
@@ -768,7 +777,9 @@ class Banana(protocol.Protocol):
             # At this point, the header and type byte have been received.
             # The body may or may not be complete.
 
-            typebyte = first65[pos]
+            # PY3KPORT
+            typebyte = ensure_byte(first65[pos])
+                
             if pos:
                 header = b1282int(first65[:pos])
             else:

--- a/src/foolscap/banana.py
+++ b/src/foolscap/banana.py
@@ -11,9 +11,9 @@ from twisted.python import log
 from foolscap.slicers.allslicers import RootSlicer, RootUnslicer
 from foolscap.slicers.allslicers import ReplaceVocabSlicer, AddVocabSlicer
 
-import stringchain
-import tokens
-from tokens import (SIZE_LIMIT, STRING, LIST, INT, NEG, 
+from . import stringchain
+from . import tokens
+from .tokens import (SIZE_LIMIT, STRING, LIST, INT, NEG, 
                     LONGINT, LONGNEG, VOCAB, FLOAT, OPEN, CLOSE, ABORT, ERROR, 
                     PING, PONG, 
                     BananaError, BananaFailure, Violation)
@@ -64,7 +64,7 @@ def long_to_bytes(n, blocksize=0):
     n = long(n)
     pack = struct.pack
     while n > 0:
-        s = pack('>I', n & 0xffffffffL) + s
+        s = pack('>I', n & long(0xffffffff)) + s
         n = n >> 32
     # strip off leading zeros
     for i in range(len(s)):
@@ -87,7 +87,7 @@ def bytes_to_long(s):
 
     This is (essentially) the inverse of long_to_bytes().
     """
-    acc = 0L
+    acc = long(0)
     unpack = struct.unpack
     length = len(s)
     if length % 4:
@@ -127,17 +127,17 @@ class Banana(protocol.Protocol):
         contents of this table.
         """
 
-        out_vocabDict = dict(zip(vocabStrings, range(len(vocabStrings))))
+        out_vocabDict = dict(list(zip(vocabStrings, list(range(len(vocabStrings))))))
         self.outgoingVocabTableWasReplaced(out_vocabDict)
 
-        in_vocabDict = dict(zip(range(len(vocabStrings)), vocabStrings))
+        in_vocabDict = dict(list(zip(list(range(len(vocabStrings))), vocabStrings)))
         self.replaceIncomingVocabulary(in_vocabDict)
 
     ### connection setup
 
     def connectionMade(self):
         if self.debugSend:
-            print "Banana.connectionMade"
+            print("Banana.connectionMade")
         self.initSlicer()
         self.initUnslicer()
         if self.keepaliveTimeout is not None:
@@ -186,12 +186,18 @@ class Banana(protocol.Protocol):
         assert tokens.IRootSlicer.providedBy(self.rootSlicer)
 
         itr = self.rootSlicer.slice()
-        next = iter(itr).next
+
+        # PY3KPORT
+        try:
+            next = iter(itr).__next__
+        except Exception:
+            next = iter(itr).next
+            
         top = (self.rootSlicer, next, None)
         self.slicerStack = [top]
 
     def send(self, obj):
-        if self.debugSend: print "Banana.send(%s)" % obj
+        if self.debugSend: print("Banana.send(%s)" % obj)
         return self.rootSlicer.send(obj)
 
     def _slice_error(self, f, s):
@@ -202,11 +208,11 @@ class Banana(protocol.Protocol):
         # optimize: cache 'next' because we get many more tokens than stack
         # pushes/pops
         while self.slicerStack and not self.paused:
-            if self.debugSend: print "produce.loop"
+            if self.debugSend: print("produce.loop")
             try:
                 slicer, next, openID = self.slicerStack[-1]
                 obj = next()
-                if self.debugSend: print " produce.obj=%s" % (obj,)
+                if self.debugSend: print(" produce.obj=%s" % (obj,))
                 if isinstance(obj, defer.Deferred):
                     for s,n,o in self.slicerStack:
                         if not s.streamable:
@@ -224,7 +230,7 @@ class Banana(protocol.Protocol):
                     try:
                         slicer = self.newSlicerFor(obj)
                         self.pushSlicer(slicer, obj)
-                    except Violation, v:
+                    except Violation as v:
                         # pushSlicer is arranged such that the pushing of
                         # the Slicer and the sending of the OPEN happen
                         # together: either both occur or neither occur. In
@@ -239,26 +245,26 @@ class Banana(protocol.Protocol):
 
                         f = BananaFailure()
                         if self.debugSend:
-                            print " violation in newSlicerFor:", f
+                            print(" violation in newSlicerFor:", f)
                         self.handleSendViolation(f,
                                                  doPop=False, sendAbort=False)
 
             except StopIteration:
-                if self.debugSend: print "StopIteration"
+                if self.debugSend: print("StopIteration")
                 self.popSlicer()
 
-            except Violation, v:
+            except Violation as v:
                 # Violations that occur because of Constraints are caught
                 # before the Slicer is pushed. A Violation that is caught
                 # here was raised inside .next(), or .streamable wasn't
                 # obeyed. The Slicer should now be abandoned.
-                if self.debugSend: print " violation in .next:", v
+                if self.debugSend: print(" violation in .next:", v)
 
                 f = BananaFailure()
                 self.handleSendViolation(f, doPop=True, sendAbort=True)
 
             except:
-                print "exception in produce"
+                print("exception in produce")
                 log.msg("exception in produce")
                 self.sendFailed(Failure())
                 # there is no point to raising this again. The Deferreds are
@@ -278,7 +284,7 @@ class Banana(protocol.Protocol):
             top = self.slicerStack[-1][0]
 
             if self.debugSend:
-                print " handleSendViolation.loop, top=%s" % top
+                print(" handleSendViolation.loop, top=%s" % top)
 
             # should we send an ABORT? Only if an OPEN has been sent, which
             # happens in pushSlicer (if at all).
@@ -286,15 +292,15 @@ class Banana(protocol.Protocol):
                 lastOpenID = self.slicerStack[-1][2]
                 if lastOpenID is not None:
                     if self.debugSend:
-                        print "  sending ABORT(%s)" % lastOpenID
+                        print("  sending ABORT(%s)" % lastOpenID)
                     self.sendAbort(lastOpenID)
 
             # should we pop the Slicer? yes
             if doPop:
-                if self.debugSend: print "  popping %s" % top
+                if self.debugSend: print("  popping %s" % top)
                 self.popSlicer()
                 if not self.slicerStack:
-                    if self.debugSend: print "RootSlicer died!"
+                    if self.debugSend: print("RootSlicer died!")
                     raise BananaError("Hey! You killed the RootSlicer!")
                 top = self.slicerStack[-1][0]
 
@@ -303,7 +309,7 @@ class Banana(protocol.Protocol):
             # RootSlicer ignores the error
 
             if self.debugSend:
-                print "  notifying parent", top
+                print("  notifying parent", top)
             f = top.childAborted(f)
 
             if f:
@@ -324,7 +330,7 @@ class Banana(protocol.Protocol):
         return topSlicer.slicerForObject(obj)
 
     def pushSlicer(self, slicer, obj):
-        if self.debugSend: print "push", slicer
+        if self.debugSend: print("push", slicer)
         assert len(self.slicerStack) < 10000 # failsafe
 
         # if this method raises a Violation, it means that .slice failed,
@@ -352,8 +358,13 @@ class Banana(protocol.Protocol):
         # methods which are *not* generators.
 
         itr = slicer.slice(topSlicer.streamable, self)
-        next = iter(itr).next
 
+        # PY3KPORT
+        try:
+            next = iter(itr).__next__
+        except Exception:
+            next = iter(itr).next
+            
         # we are now committed to sending the OPEN token, meaning that
         # failures after this point will cause an ABORT/CLOSE to be sent
 
@@ -373,7 +384,7 @@ class Banana(protocol.Protocol):
         slicer, next, openID = self.slicerStack.pop()
         if openID is not None:
             self.sendClose(openID)
-        if self.debugSend: print "pop", slicer
+        if self.debugSend: print("pop", slicer)
 
     def describeSend(self):
         where = []
@@ -411,7 +422,7 @@ class Banana(protocol.Protocol):
         assert isinstance(vocabStrings, (list, tuple))
         for s in vocabStrings:
             assert isinstance(s, str)
-        vocabDict = dict(zip(vocabStrings, range(len(vocabStrings))))
+        vocabDict = dict(list(zip(vocabStrings, list(range(len(vocabStrings))))))
         s = ReplaceVocabSlicer(vocabDict)
         # the ReplaceVocabSlicer does some magic to insure the VOCAB message
         # does not use vocab tokens itself. This would be legal (sort of a
@@ -494,7 +505,7 @@ class Banana(protocol.Protocol):
 
     def sendToken(self, obj):
         write = self.transport.write
-        if isinstance(obj, (int, long)):
+        if isinstance(obj, six.integer_types):
             if obj >= 2**31:
                 s = long_to_bytes(obj)
                 int2b128(len(s), write)
@@ -515,7 +526,7 @@ class Banana(protocol.Protocol):
             write(FLOAT)
             write(struct.pack("!d", obj))
         elif isinstance(obj, str):
-            if self.outgoingVocabulary.has_key(obj):
+            if obj in self.outgoingVocabulary:
                 symbolID = self.outgoingVocabulary[obj]
                 int2b128(symbolID, write)
                 write(VOCAB)
@@ -525,7 +536,7 @@ class Banana(protocol.Protocol):
                 write(STRING)
                 write(obj)
         else:
-            raise BananaError, "could not send object: %s" % repr(obj)
+            raise BananaError("could not send object: %s" % repr(obj))
 
     def maybeVocabizeString(self, string):
         # TODO: keep track of the last 30 strings we've send in full. If this
@@ -558,19 +569,19 @@ class Banana(protocol.Protocol):
         # call this if an exception is raised in transmission. The Failure
         # will be logged and the connection will be dropped. This is
         # suitable for use as an errback handler.
-        print "SendBanana.sendFailed:", f
+        print("SendBanana.sendFailed:", f)
         log.msg("Sendfailed.sendfailed")
         log.err(f)
         try:
             if self.transport:
                 self.transport.loseConnection()
         except:
-            print "exception during transport.loseConnection"
+            print("exception during transport.loseConnection")
             log.err()
         try:
             self.rootSlicer.connectionLost(f)
         except:
-            print "exception during rootSlicer.connectionLost"
+            print("exception during rootSlicer.connectionLost")
             log.err()
 
     ### ReceiveBanana
@@ -610,14 +621,14 @@ class Banana(protocol.Protocol):
         self.objects = {}
 
     def printStack(self, verbose=0):
-        print "STACK:"
+        print("STACK:")
         for s in self.receiveStack:
             if verbose:
                 d = s.__dict__.copy()
                 del d['protocol']
-                print " %s: %s" % (s, d)
+                print(" %s: %s" % (s, d))
             else:
-                print " %s" % s
+                print(" %s" % s)
 
     def setObject(self, count, obj):
         for i in range(len(self.receiveStack)-1, -1, -1):
@@ -628,7 +639,7 @@ class Banana(protocol.Protocol):
             obj = self.receiveStack[i].getObject(count)
             if obj is not None:
                 return obj
-        raise ValueError, "dangling reference '%d'" % count
+        raise ValueError("dangling reference '%d'" % count)
 
 
     def replaceIncomingVocabulary(self, vocabDict):
@@ -647,7 +658,7 @@ class Banana(protocol.Protocol):
             self.dataLastReceivedAt = time.time()
         try:
             self.handleData(chunk)
-        except Exception, e:
+        except Exception as e:
             if isinstance(e, BananaError):
                 # only reveal the reason if it is a protocol error
                 e.where = self.describeReceive()
@@ -851,14 +862,14 @@ class Banana(protocol.Protocol):
                 self.inboundOpenCount = header
                 if rejected:
                     if self.debugReceive:
-                        print "DROP (OPEN)"
+                        print("DROP (OPEN)")
                     if self.inOpen:
                         # we are discarding everything at the old level, so
                         # discard everything in the new level too
                         self.discardCount += 1
                         if self.debugReceive:
-                            print "++discardCount (OPEN), now %d" \
-                                  % self.discardCount
+                            print("++discardCount (OPEN), now %d" \
+                                  % self.discardCount)
                         self.inOpen = False
                     else:
                         # the checkToken handleViolation has already started
@@ -874,8 +885,8 @@ class Banana(protocol.Protocol):
                 if self.discardCount:
                     self.discardCount -= 1
                     if self.debugReceive:
-                        print "--discardCount (CLOSE), now %d" \
-                              % self.discardCount
+                        print("--discardCount (CLOSE), now %d" \
+                              % self.discardCount)
                 else:
                     self.handleClose(count)
                 continue
@@ -889,7 +900,7 @@ class Banana(protocol.Protocol):
                 # tokens just as if the Unslicer had made the decision.
                 if rejected:
                     if self.debugReceive:
-                        print "DROP (ABORT)"
+                        print("DROP (ABORT)")
                     # I'm ignoring you, LALALALALA.
                     #
                     # In particular, do not deliver a second Violation
@@ -934,7 +945,7 @@ class Banana(protocol.Protocol):
                         # drop all we have and note how much more should be
                         # dropped
                         if self.debugReceive:
-                            print "DROPPED some string bits"
+                            print("DROPPED some string bits")
                         self.skipBytes = strlen - len(self.buffer)
                         self.buffer.clear()
                     else:
@@ -946,7 +957,7 @@ class Banana(protocol.Protocol):
             elif typebyte == NEG:
                 # -2**31 is too large for a positive int, so go through
                 # LongType first
-                obj = int(-long(header))
+                obj = int(-int(header))
             elif typebyte == LONGINT or typebyte == LONGNEG:
                 strlen = header
                 if len(self.buffer) >= strlen:
@@ -1003,7 +1014,7 @@ class Banana(protocol.Protocol):
                     self.handleToken(obj)
             else:
                 if self.debugReceive:
-                    print "DROP", type(obj), obj
+                    print("DROP", type(obj), obj)
                 pass # drop the object
 
             # while loop ends here
@@ -1017,17 +1028,17 @@ class Banana(protocol.Protocol):
         self.opentype.append(indexToken)
         opentype = tuple(self.opentype)
         if self.debugReceive:
-            print "handleOpen(%d,%d,%s)" % (openCount, objectCount, indexToken)
+            print("handleOpen(%d,%d,%s)" % (openCount, objectCount, indexToken))
         top = self.receiveStack[-1]
         try:
             # obtain a new Unslicer to handle the object
             child = top.doOpen(opentype)
             if not child:
                 if self.debugReceive:
-                    print " doOpen wants more index tokens"
+                    print(" doOpen wants more index tokens")
                 return # they want more index tokens, leave .inOpen=True
             if self.debugReceive:
-                print " opened[%d] with %s" % (openCount, child)
+                print(" opened[%d] with %s" % (openCount, child))
         except Violation:
             # must discard the rest of the child object. There is no new
             # unslicer pushed yet, so we don't use abandonUnslicer
@@ -1053,7 +1064,7 @@ class Banana(protocol.Protocol):
 
     def handleToken(self, token, ready_deferred=None):
         top = self.receiveStack[-1]
-        if self.debugReceive: print "handleToken(%s)" % (token,)
+        if self.debugReceive: print("handleToken(%s)" % (token,))
         if ready_deferred:
             assert isinstance(ready_deferred, defer.Deferred)
         try:
@@ -1067,7 +1078,7 @@ class Banana(protocol.Protocol):
 
     def handleClose(self, closeCount):
         if self.debugReceive:
-            print "handleClose(%d)" % closeCount
+            print("handleClose(%d)" % closeCount)
         if self.receiveStack[-1].openCount != closeCount:
             raise BananaError("lost sync, got CLOSE(%d) but expecting %s" \
                               % (closeCount, self.receiveStack[-1].openCount))
@@ -1083,7 +1094,7 @@ class Banana(protocol.Protocol):
             f = BananaFailure()
             self.handleViolation(f, "receiveClose", inClose=True)
             return
-        if self.debugReceive: print "receiveClose returned", obj
+        if self.debugReceive: print("receiveClose returned", obj)
 
         try:
             child.finish()
@@ -1120,8 +1131,8 @@ class Banana(protocol.Protocol):
         f.value.setLocation(where)
 
         if self.debugReceive:
-            print " handleViolation-%s (inOpen=%s, inClose=%s): %s" \
-                  % (methname, inOpen, inClose, f)
+            print(" handleViolation-%s (inOpen=%s, inClose=%s): %s" \
+                  % (methname, inOpen, inClose, f))
 
         assert isinstance(f, BananaFailure)
 
@@ -1132,28 +1143,28 @@ class Banana(protocol.Protocol):
         if inOpen:
             self.discardCount += 1
             if self.debugReceive:
-                print "  ++discardCount (inOpen), now %d" % self.discardCount
+                print("  ++discardCount (inOpen), now %d" % self.discardCount)
 
         while True:
             # tell the parent that their child is dead. This is useful for
             # things like PB, which may want to errback the current request.
             if self.debugReceive:
-                print " reportViolation to %s" % self.receiveStack[-1]
+                print(" reportViolation to %s" % self.receiveStack[-1])
             f = self.receiveStack[-1].reportViolation(f)
             if not f:
                 # they absorbed the failure
                 if self.debugReceive:
-                    print "  buck stopped, error absorbed"
+                    print("  buck stopped, error absorbed")
                 break
 
             # the old top wants to propagate it upwards
             if self.debugReceive:
-                print "  popping %s" % self.receiveStack[-1]
+                print("  popping %s" % self.receiveStack[-1])
             if not inClose:
                 self.discardCount += 1
                 if self.debugReceive:
-                    print "  ++discardCount (pop, not inClose), now %d" \
-                          % self.discardCount
+                    print("  ++discardCount (pop, not inClose), now %d" \
+                          % self.discardCount)
             inClose = False
 
             old = self.receiveStack.pop()

--- a/src/foolscap/broker.py
+++ b/src/foolscap/broker.py
@@ -5,7 +5,7 @@
 import types, time
 from itertools import count
 
-from zope.interface import implements
+from zope.interface import implementer
 from twisted.python import failure
 from twisted.internet import defer, error
 from twisted.internet import interfaces as twinterfaces
@@ -129,6 +129,7 @@ class RIBroker(remoteinterface.RemoteInterface):
         return None
 
 
+@implementer(RIBroker, IBroker)
 class Broker(banana.Banana, referenceable.Referenceable):
     """I manage a connection to a remote Broker.
 
@@ -139,7 +140,6 @@ class Broker(banana.Banana, referenceable.Referenceable):
 
     """
 
-    implements(RIBroker, IBroker)
     slicerClass = PBRootSlicer
     unslicerClass = PBRootUnslicer
     unsafeTracebacks = True
@@ -733,12 +733,13 @@ class StorageBroker(Broker):
 # we use it for real, not just for testing. The IConsumer stuff hasn't been
 # tested at all.
 
+@implementer(twinterfaces.IAddress)
 class LoopbackAddress(object):
-    implements(twinterfaces.IAddress)
+    pass
 
+@implementer(twinterfaces.ITransport, twinterfaces.IConsumer)
 class LoopbackTransport(object):
     # we always create these in pairs, with .peer pointing at each other
-    implements(twinterfaces.ITransport, twinterfaces.IConsumer)
 
     producer = None
 

--- a/src/foolscap/constraint.py
+++ b/src/foolscap/constraint.py
@@ -6,7 +6,7 @@
 # This imports foolscap.tokens, but no other Foolscap modules.
 
 import re
-from zope.interface import implements, Interface
+from zope.interface import implementer, Interface
 
 from foolscap.tokens import Violation, BananaError, SIZE_LIMIT, \
      STRING, LIST, INT, NEG, LONGINT, LONGNEG, VOCAB, FLOAT, OPEN, \
@@ -65,14 +65,13 @@ class IRemoteMethodConstraint(IConstraint):
 
         This should either raise Violation or return None."""
 
+@implementer(IConstraint)
 class Constraint(object):
     """
     Each __schema__ attribute is turned into an instance of this class, and
     is eventually given to the unserializer (the 'Unslicer') to enforce as
     the tokens are arriving off the wire.
     """
-
-    implements(IConstraint)
 
     taster = everythingTaster
     """the Taster is a dict that specifies which basic token types are

--- a/src/foolscap/constraint.py
+++ b/src/foolscap/constraint.py
@@ -5,12 +5,13 @@
 
 # This imports foolscap.tokens, but no other Foolscap modules.
 
+import six
 import re
 from zope.interface import implementer, Interface
 
-from foolscap.tokens import Violation, BananaError, SIZE_LIMIT, \
-     STRING, LIST, INT, NEG, LONGINT, LONGNEG, VOCAB, FLOAT, OPEN, \
-     tokenNames
+from foolscap.tokens import (Violation, BananaError, SIZE_LIMIT, 
+                             STRING, LIST, INT, NEG, LONGINT, LONGNEG, VOCAB, FLOAT, OPEN, 
+                             tokenNames)
 
 everythingTaster = {
     # he likes everything
@@ -243,7 +244,7 @@ class IntegerConstraint(Constraint):
             self.taster[LONGNEG] = maxBytes
 
     def checkObject(self, obj, inbound):
-        if not isinstance(obj, (int, long)):
+        if not isinstance(obj, six.integer_types):
             raise Violation("'%r' is not a number" % (obj,))
         if self.maxBytes == -1:
             if obj >= 2**31 or obj < -2**31:

--- a/src/foolscap/copyable.py
+++ b/src/foolscap/copyable.py
@@ -2,7 +2,7 @@
 
 # this module is responsible for all copy-by-value objects
 
-from zope.interface import interface, implements
+from zope.interface import interface, implementer
 from twisted.python import reflect, log
 from twisted.python.components import registerAdapter
 from twisted.internet import defer
@@ -29,8 +29,9 @@ class ICopyable(Interface):
         serialized and sent to the remote end. This state object will be
         given to the receiving object's setCopyableState method."""
 
+@implementer(ICopyable)
 class Copyable(object):
-    implements(ICopyable)
+
     # you *must* set 'typeToCopy'
 
     def getTypeToCopy(self):
@@ -86,8 +87,9 @@ def registerCopier(klass, copier):
     classname is used.
     """
     klassname = reflect.qual(klass)
+
+    @implementer(ICopyable)
     class _CopierAdapter:
-        implements(ICopyable)
         def __init__(self, original):
             self.nameToCopy, self.state = copier(original)
             if self.nameToCopy is None:
@@ -323,9 +325,8 @@ class RemoteCopyClass(type):
             registry = dict.get('copyableRegistry', None)
             registerRemoteCopy(copytype, self, registry)
 
+@implementer(IRemoteCopy)
 class _RemoteCopyBase:
-
-    implements(IRemoteCopy)
 
     stateSchema = None # always a class attribute
     nonCyclic = False

--- a/src/foolscap/copyable.py
+++ b/src/foolscap/copyable.py
@@ -7,8 +7,8 @@ from twisted.python import reflect, log
 from twisted.python.components import registerAdapter
 from twisted.internet import defer
 
-import slicer, tokens
-from tokens import BananaError, Violation
+from . import slicer, tokens
+from .tokens import BananaError, Violation
 from foolscap.constraint import OpenerConstraint, IConstraint, Optional
 
 Interface = interface.Interface
@@ -388,8 +388,8 @@ class AttributeDictConstraint(OpenerConstraint):
 
     def checkObject(self, obj, inbound):
         if type(obj) != type({}):
-            raise Violation, "'%s' (%s) is not a Dictionary" % (obj,
-                                                                type(obj))
+            raise Violation("'%s' (%s) is not a Dictionary" % (obj,
+                                                                type(obj)))
         allkeys = self.keys.keys()
         for k in obj.keys():
             try:
@@ -397,7 +397,7 @@ class AttributeDictConstraint(OpenerConstraint):
                 allkeys.remove(k)
             except KeyError:
                 if not self.ignoreUnknown:
-                    raise Violation, "key '%s' not in schema" % k
+                    raise Violation("key '%s' not in schema" % k)
                 else:
                     # hmm. kind of a soft violation. allow it for now.
                     pass

--- a/src/foolscap/logging/gatherer.py
+++ b/src/foolscap/logging/gatherer.py
@@ -5,7 +5,7 @@ try:
     import signal
 except ImportError:
     pass
-from zope.interface import implements
+from zope.interface import implementer
 from twisted.internet import reactor, utils, defer
 from twisted.python import usage, procutils, filepath, log as tw_log
 from twisted.application import service, internet
@@ -103,9 +103,8 @@ class CreateGatherOptions(usage.Options):
         if not self["location"]:
             raise usage.UsageError("--location= is mandatory")
 
-
+@implementer(RILogObserver)
 class Observer(Referenceable):
-    implements(RILogObserver)
 
     def __init__(self, nodeid_s, gatherer):
         self.nodeid_s = nodeid_s # printable string
@@ -114,6 +113,7 @@ class Observer(Referenceable):
     def remote_msg(self, d):
         self.gatherer.msg(self.nodeid_s, d)
 
+@implementer(RILogGatherer)
 class GathererService(GatheringBase):
     # create this with 'flogtool create-gatherer BASEDIR'
     # run this as 'cd BASEDIR && twistd -y gatherer.tac'
@@ -148,7 +148,6 @@ class GathererService(GatheringBase):
 
     """
 
-    implements(RILogGatherer)
     verbose = True
     furlFile = "log_gatherer.furl"
     tacFile = "gatherer.tac"
@@ -327,9 +326,8 @@ class CreateIncidentGatherOptions(usage.Options):
         if not self["location"]:
             raise usage.UsageError("--location= is mandatory")
 
-
+@implementer(RILogObserver)
 class IncidentObserver(Referenceable):
-    implements(RILogObserver)
 
     def __init__(self, basedir, tubid_s, gatherer, publisher, stdout):
         if not os.path.isdir(basedir):
@@ -421,6 +419,7 @@ class IncidentObserver(Referenceable):
         self.caught_up_d.callback(None)
         return None
 
+@implementer(RILogGatherer)
 class IncidentGathererService(GatheringBase, IncidentClassifierBase):
     # create this with 'flogtool create-incident-gatherer BASEDIR'
     # run this as 'cd BASEDIR && twistd -y gatherer.tac'
@@ -443,7 +442,6 @@ class IncidentGathererService(GatheringBase, IncidentClassifierBase):
 
     """
 
-    implements(RILogGatherer)
     verbose = True
     furlFile = "log_gatherer.furl"
     tacFile = "gatherer.tac"

--- a/src/foolscap/logging/incident.py
+++ b/src/foolscap/logging/incident.py
@@ -1,7 +1,7 @@
 
 import sys, os.path, time, bz2
 from pprint import pprint
-from zope.interface import implements
+from zope.interface import implementer
 from twisted.python import usage
 from twisted.internet import reactor
 from foolscap.logging.interfaces import IIncidentReporter
@@ -37,6 +37,7 @@ class IncidentQualifier:
         if self.check_event(ev) and self.handler:
             self.handler.declare_incident(ev)
 
+@implementer(IIncidentReporter)
 class IncidentReporter:
     """Once an Incident has been declared, I am responsible for making a
     durable record all relevant log events. I do this by creating a logfile
@@ -55,7 +56,6 @@ class IncidentReporter:
     of the logfile I created and the triggering event. This can be used to
     notify remote subscribers about the incident that just occurred.
     """
-    implements(IIncidentReporter)
 
     TRAILING_DELAY = 5.0 # gather 5 seconds of post-trigger events
     TRAILING_EVENT_LIMIT = 100 # or 100 events, whichever comes first

--- a/src/foolscap/logging/publish.py
+++ b/src/foolscap/logging/publish.py
@@ -1,15 +1,16 @@
 
 import os
 from collections import deque
-from zope.interface import implements
+from zope.interface import implementer
 from twisted.python import filepath
 from foolscap.referenceable import Referenceable
 from foolscap.logging.interfaces import RISubscription, RILogPublisher
 from foolscap.logging import app_versions, flogfile
 from foolscap.eventual import eventually
 
+@implementer(RISubscription)
 class Subscription(Referenceable):
-    implements(RISubscription)
+
     # used as a marker, and as an unsubscribe() method. We use this to manage
     # the outbound size-limited queue.
     MAX_QUEUE_SIZE = 2000
@@ -88,8 +89,8 @@ class Subscription(Referenceable):
         #print "PUBLISH FAILED: %s" % f
         self.unsubscribe()
 
+@implementer(RISubscription)
 class IncidentSubscription(Referenceable):
-    implements(RISubscription)
 
     def __init__(self, observer, logger, publisher):
         self.observer = observer
@@ -140,6 +141,7 @@ def _keys_to_bytes(d):
     # these dicts, which are unconstrained (the schemas use Any())
     return dict([ (k.encode("ascii"), v) for (k,v) in d.iteritems()])
 
+@implementer(RILogPublisher)
 class LogPublisher(Referenceable):
     """Publish log events to anyone subscribed to our 'logport'.
 
@@ -170,8 +172,6 @@ class LogPublisher(Referenceable):
     will cause the Tub to connect to the gatherer and grant it access to the
     logport.
     """
-
-    implements(RILogPublisher)
 
     # the 'versions' dict used to live here in LogPublisher, but now it lives
     # in foolscap.logging.app_versions and should be accessed from there.

--- a/src/foolscap/logging/tail.py
+++ b/src/foolscap/logging/tail.py
@@ -1,6 +1,6 @@
 
 import os, sys, time
-from zope.interface import implements
+from zope.interface import implementer
 from twisted.internet import reactor
 from twisted.python import usage
 from foolscap import base32
@@ -13,8 +13,9 @@ from interfaces import RILogObserver
 def short_tubid_b2a(tubid):
     return base32.encode(tubid)[:8]
 
+@implementer(RILogObserver)
 class LogSaver(Referenceable):
-    implements(RILogObserver)
+    
     def __init__(self, nodeid_s, savefile):
         self.nodeid_s = nodeid_s
         self.f = savefile # we own this, and may close it
@@ -66,8 +67,8 @@ class TailOptions(usage.Options):
         else:
             raise RuntimeError("Can't use tail target: %s" % target)
 
+@implementer(RILogObserver)
 class LogPrinter(Referenceable):
-    implements(RILogObserver)
 
     def __init__(self, options, target_tubid_s, output=sys.stdout):
         self.options = options

--- a/src/foolscap/pb.py
+++ b/src/foolscap/pb.py
@@ -2,7 +2,7 @@
 
 import os.path, weakref, binascii, re
 from warnings import warn
-from zope.interface import implements
+from zope.interface import implementer
 from twisted.internet import (reactor, defer, protocol, error, interfaces,
                               endpoints)
 from twisted.application import service
@@ -118,6 +118,7 @@ def generateSwissnumber(bits):
     bytes = os.urandom(bits/8)
     return base32.encode(bytes)
 
+@implementer(ipb.ITub)
 class Tub(service.MultiService):
     """I am a presence in the PB universe, also known as a Tub.
 
@@ -169,7 +170,6 @@ class Tub(service.MultiService):
                  authentication information, hash of SSL certificate
 
     """
-    implements(ipb.ITub)
 
     unsafeTracebacks = True # TODO: better way to enable this
     logLocalFailures = False

--- a/src/foolscap/referenceable.py
+++ b/src/foolscap/referenceable.py
@@ -6,7 +6,7 @@
 
 import weakref
 from zope.interface import interface
-from zope.interface import implements
+from zope.interface import implementer
 from twisted.python.components import registerAdapter
 Interface = interface.Interface
 from twisted.internet import defer
@@ -23,14 +23,14 @@ from foolscap.copyable import Copyable, RemoteCopy
 from foolscap.eventual import eventually, fireEventually
 from foolscap.furl import decode_furl
 
+@implementer(ipb.IReferenceable)
 class OnlyReferenceable(object):
-    implements(ipb.IReferenceable)
 
     def processUniqueID(self):
         return id(self)
 
+@implementer(ipb.IReferenceable, ipb.IRemotelyCallable)
 class Referenceable(OnlyReferenceable):
-    implements(ipb.IReferenceable, ipb.IRemotelyCallable)
     _interface = None
     _interfaceName = None
 
@@ -336,9 +336,8 @@ class RemoteReferenceTracker(object):
         # between the call to _refLost and the eventual call to
         # _handleRefLost. In this case, don't decref anything.
 
-
+@implementer(ipb.IRemoteReference)
 class RemoteReferenceOnly(object):
-    implements(ipb.IRemoteReference)
 
     def __init__(self, tracker):
         """@param tracker: the RemoteReferenceTracker which points to us"""
@@ -606,8 +605,9 @@ class RemoteMethodReference(RemoteReference):
         methodSchema = None
         return interfaceName, methodName, methodSchema
 
+@implementer(ipb.IRemoteReference)
 class LocalReferenceable(object):
-    implements(ipb.IRemoteReference)
+
     def __init__(self, original):
         self.original = original
 

--- a/src/foolscap/remoteinterface.py
+++ b/src/foolscap/remoteinterface.py
@@ -1,7 +1,7 @@
 
 import types
 import inspect
-from zope.interface import interface, providedBy, implements
+from zope.interface import interface, providedBy, implementer
 from foolscap.constraint import Constraint, OpenerConstraint, nothingTaster, \
      IConstraint, IRemoteMethodConstraint, Optional, Any
 from foolscap.tokens import Violation, InvalidRemoteInterface
@@ -131,6 +131,8 @@ def getRemoteInterfaceByName(iname):
 
 
 
+
+@implementer(IRemoteMethodConstraint)
 class RemoteMethodSchema(object):
     """
     This is a constraint for a single remotely-invokable method. It gets to
@@ -149,8 +151,6 @@ class RemoteMethodSchema(object):
     The remotely-accesible object's .getMethodSchema() method may return one
     of these objects.
     """
-
-    implements(IRemoteMethodConstraint)
 
     taster = {} # this should not be used as a top-level constraint
     opentypes = [] # overkill
@@ -296,6 +296,7 @@ class RemoteMethodSchema(object):
             # location appropriately: they have more information than we do.
             self.responseConstraint.checkObject(results, inbound)
 
+@implementer(IRemoteMethodConstraint)
 class UnconstrainedMethod(object):
     """I am a method constraint that accepts any arguments and any return
     value.
@@ -307,7 +308,6 @@ class UnconstrainedMethod(object):
              return str
          not_method = UnconstrainedMethod()  # this one is not
     """
-    implements(IRemoteMethodConstraint)
 
     def getPositionalArgConstraint(self, argnum):
         return (True, Any())

--- a/src/foolscap/schema.py
+++ b/src/foolscap/schema.py
@@ -54,12 +54,14 @@ modifiers:
 
 """
 
-from foolscap.tokens import Violation, UnknownSchemaType, BananaError, \
-     tokenNames
+import six
+from foolscap.tokens import (Violation, UnknownSchemaType,
+                             BananaError, tokenNames)
 
 # make constraints available in a single location
-from foolscap.constraint import Constraint, Any, ByteStringConstraint, \
-     IntegerConstraint, NumberConstraint, IConstraint, Optional, Shared
+from foolscap.constraint import (Constraint, Any, ByteStringConstraint, 
+                                 IntegerConstraint, NumberConstraint, IConstraint,
+                                 Optional, Shared)
 from foolscap.slicers.unicode import UnicodeConstraint
 from foolscap.slicers.bool import BooleanConstraint
 from foolscap.slicers.dict import DictConstraint
@@ -82,7 +84,10 @@ ListOf = ListConstraint
 DictOf = DictConstraint
 SetOf = SetConstraint
 
-
+if six.PY3:
+    unicode = str
+    long = int
+    
 # note: using PolyConstraint (aka ChoiceOf) for inbound tasting is probably
 # not fully vetted. One of the issues would be with something like
 # ListOf(ChoiceOf(TupleOf(stuff), SetOf(stuff))). The ListUnslicer, when
@@ -126,8 +131,11 @@ class PolyConstraint(Constraint):
 ChoiceOf = PolyConstraint
 
 def AnyStringConstraint(*args, **kwargs):
-    return ChoiceOf(ByteStringConstraint(*args, **kwargs),
-                    UnicodeConstraint(*args, **kwargs))
+    if six.PY2:
+        return ChoiceOf(ByteStringConstraint(*args, **kwargs),
+                        UnicodeConstraint(*args, **kwargs))
+    else:
+        return ByteStringConstraint(*args, **kwargs)
 
 # keep the old meaning, for now. Eventually StringConstraint should become an
 # AnyStringConstraint
@@ -135,7 +143,6 @@ StringConstraint = ByteStringConstraint
 
 constraintMap = {
     str: ByteStringConstraint(),
-    unicode: UnicodeConstraint(),
     bool: BooleanConstraint(),
     int: IntegerConstraint(),
     long: IntegerConstraint(maxBytes=1024),
@@ -143,6 +150,9 @@ constraintMap = {
     None: Nothing(),
     }
 
+if six.PY2:
+    constraintMap[unicode] = UnicodeConstraint()
+    
 # This module provides a function named addToConstraintTypeMap() which helps
 # to resolve some import cycles.
 

--- a/src/foolscap/slicer.py
+++ b/src/foolscap/slicer.py
@@ -272,13 +272,13 @@ class ScopedUnslicer(BaseUnslicer):
 
     def setObject(self, counter, obj):
         if self.protocol.debugReceive:
-            print("setObject(%s): %s{%s}" % (counter, obj, id(obj)))
+            print(("setObject(%s): %s{%s}" % (counter, obj, id(obj))))
         self.references[counter] = obj
 
     def getObject(self, counter):
         obj = self.references.get(counter)
         if self.protocol.debugReceive:
-            print("getObject(%s) -> %s{%s}" % (counter, obj, id(obj)))
+            print(("getObject(%s) -> %s{%s}" % (counter, obj, id(obj))))
         return obj
 
 

--- a/src/foolscap/slicer.py
+++ b/src/foolscap/slicer.py
@@ -1,12 +1,15 @@
 # -*- test-case-name: foolscap.test.test_banana -*-
 
+import six
 from twisted.python.components import registerAdapter
 from twisted.python import log
 from zope.interface import implementer
 from twisted.internet.defer import Deferred
-import tokens
-from tokens import Violation, BananaError
+from . import tokens
+from .tokens import Violation, BananaError
 from foolscap.ipb import IBroker
+# PY3KPORT
+from six import with_metaclass 
 
 class SlicerClass(type):
     # auto-register Slicers
@@ -19,8 +22,7 @@ class SlicerClass(type):
 
 
 @implementer(tokens.ISlicer)
-class BaseSlicer(object):
-    __metaclass__ = SlicerClass
+class BaseSlicer(with_metaclass(SlicerClass, object)):
 
     slices = None
 
@@ -129,11 +131,22 @@ UnslicerRegistry = {}
 BananaUnslicerRegistry = {}
 
 def registerUnslicer(opentype, factory, registry=None):
+
     if registry is None:
         registry = UnslicerRegistry
-    assert not registry.has_key(opentype)
+    assert opentype not in registry
+
+
     registry[opentype] = factory
 
+    # PY3KPORT  
+    if type(opentype) is tuple:
+        key = (six.ensure_binary(opentype[0]),)
+    else:
+        key = six.ensure_binary(opentype)
+
+    registry[key] = factory
+        
 class UnslicerClass(type):
     # auto-register Unslicers
     def __init__(self, name, bases, dict):
@@ -144,8 +157,7 @@ class UnslicerClass(type):
             registerUnslicer(opentype, self, reg)
 
 @implementer(tokens.IUnslicer)
-class BaseUnslicer(object):
-    __metaclass__ = UnslicerClass
+class BaseUnslicer(with_metaclass(UnslicerClass, object)):
     opentype = None
 
     def __init__(self):
@@ -260,13 +272,13 @@ class ScopedUnslicer(BaseUnslicer):
 
     def setObject(self, counter, obj):
         if self.protocol.debugReceive:
-            print "setObject(%s): %s{%s}" % (counter, obj, id(obj))
+            print("setObject(%s): %s{%s}" % (counter, obj, id(obj)))
         self.references[counter] = obj
 
     def getObject(self, counter):
         obj = self.references.get(counter)
         if self.protocol.debugReceive:
-            print "getObject(%s) -> %s{%s}" % (counter, obj, id(obj))
+            print("getObject(%s) -> %s{%s}" % (counter, obj, id(obj)))
         return obj
 
 

--- a/src/foolscap/slicer.py
+++ b/src/foolscap/slicer.py
@@ -2,7 +2,7 @@
 
 from twisted.python.components import registerAdapter
 from twisted.python import log
-from zope.interface import implements
+from zope.interface import implementer
 from twisted.internet.defer import Deferred
 import tokens
 from tokens import Violation, BananaError
@@ -18,9 +18,9 @@ class SlicerClass(type):
             registerAdapter(self, typ, tokens.ISlicer)
 
 
+@implementer(tokens.ISlicer)
 class BaseSlicer(object):
     __metaclass__ = SlicerClass
-    implements(tokens.ISlicer)
 
     slices = None
 
@@ -143,10 +143,10 @@ class UnslicerClass(type):
         if opentype:
             registerUnslicer(opentype, self, reg)
 
+@implementer(tokens.IUnslicer)
 class BaseUnslicer(object):
     __metaclass__ = UnslicerClass
     opentype = None
-    implements(tokens.IUnslicer)
 
     def __init__(self):
         pass

--- a/src/foolscap/slicer.py
+++ b/src/foolscap/slicer.py
@@ -272,13 +272,13 @@ class ScopedUnslicer(BaseUnslicer):
 
     def setObject(self, counter, obj):
         if self.protocol.debugReceive:
-            print(("setObject(%s): %s{%s}" % (counter, obj, id(obj))))
+            print("setObject(%s): %s{%s}" % (counter, obj, id(obj)))
         self.references[counter] = obj
 
     def getObject(self, counter):
         obj = self.references.get(counter)
         if self.protocol.debugReceive:
-            print(("getObject(%s) -> %s{%s}" % (counter, obj, id(obj))))
+            print("getObject(%s) -> %s{%s}" % (counter, obj, id(obj)))
         return obj
 
 

--- a/src/foolscap/slicers/bool.py
+++ b/src/foolscap/slicers/bool.py
@@ -1,5 +1,6 @@
 # -*- test-case-name: foolscap.test.test_banana -*-
 
+import six
 from twisted.python.components import registerAdapter
 from twisted.internet.defer import Deferred
 from foolscap import tokens
@@ -54,7 +55,7 @@ class BooleanUnslicer(LeafUnslicer):
 
 class BooleanConstraint(OpenerConstraint):
     strictTaster = True
-    opentypes = [("boolean",)]
+    opentypes = [(six.b("boolean"),)]
     _myint = IntegerConstraint()
     name = "BooleanConstraint"
 

--- a/src/foolscap/slicers/decimal_slicer.py
+++ b/src/foolscap/slicers/decimal_slicer.py
@@ -1,5 +1,6 @@
 # -*- test-case-name: foolscap.test.test_banana -*-
 
+import six
 import decimal
 from twisted.internet.defer import Deferred
 from foolscap.tokens import BananaError, STRING, VOCAB
@@ -33,7 +34,7 @@ class DecimalUnslicer(LeafUnslicer):
         assert ready_deferred is None
         if self.value != None:
             raise BananaError("already received a string")
-        self.value = decimal.Decimal(obj)
+        self.value = decimal.Decimal(six.ensure_str(obj, 'latin1'))
 
     def receiveClose(self):
         return self.value, None

--- a/src/foolscap/slicers/dict.py
+++ b/src/foolscap/slicers/dict.py
@@ -1,5 +1,6 @@
 # -*- test-case-name: foolscap.test.test_banana -*-
 
+import six
 from twisted.python import log
 from twisted.internet.defer import Deferred
 from foolscap.tokens import Violation, BananaError
@@ -12,7 +13,7 @@ class DictSlicer(BaseSlicer):
     trackReferences = True
     slices = None
     def sliceBody(self, streamable, banana):
-        for key,value in self.obj.items():
+        for key,value in list(self.obj.items()):
             yield key
             yield value
 
@@ -91,7 +92,7 @@ class DictUnslicer(BaseUnslicer):
         if isinstance(key, Deferred):
             raise BananaError("incomplete object as dictionary key")
         try:
-            if self.d.has_key(key):
+            if key in self.d:
                 raise BananaError("duplicate key '%s'" % key)
         except TypeError:
             raise BananaError("unhashable key '%s'" % key)
@@ -119,7 +120,7 @@ class DictUnslicer(BaseUnslicer):
 class OrderedDictSlicer(DictSlicer):
     slices = dict
     def sliceBody(self, streamable, banana):
-        keys = self.obj.keys()
+        keys = list(self.obj.keys())
         keys.sort()
         for key in keys:
             value = self.obj[key]
@@ -128,7 +129,7 @@ class OrderedDictSlicer(DictSlicer):
 
 
 class DictConstraint(OpenerConstraint):
-    opentypes = [("dict",)]
+    opentypes = [(six.b("dict"),)]
     name = "DictConstraint"
 
     def __init__(self, keyConstraint, valueConstraint, maxKeys=None):
@@ -137,11 +138,11 @@ class DictConstraint(OpenerConstraint):
         self.maxKeys = maxKeys
     def checkObject(self, obj, inbound):
         if not isinstance(obj, dict):
-            raise Violation, "'%s' (%s) is not a Dictionary" % (obj,
-                                                                type(obj))
+            raise Violation("'%s' (%s) is not a Dictionary" % (obj,
+                                                                type(obj)))
         if self.maxKeys != None and len(obj) > self.maxKeys:
-            raise Violation, "Dict keys=%d > maxKeys=%d" % (len(obj),
-                                                            self.maxKeys)
-        for key, value in obj.iteritems():
+            raise Violation("Dict keys=%d > maxKeys=%d" % (len(obj),
+                                                            self.maxKeys))
+        for key, value in obj.items():
             self.keyConstraint.checkObject(key, inbound)
             self.valueConstraint.checkObject(value, inbound)

--- a/src/foolscap/slicers/list.py
+++ b/src/foolscap/slicers/list.py
@@ -1,5 +1,6 @@
 # -*- test-case-name: foolscap.test.test_banana -*-
 
+import six
 from twisted.python import log
 from twisted.internet.defer import Deferred
 from foolscap.tokens import Violation
@@ -99,8 +100,8 @@ class ListUnslicer(BaseUnslicer):
             self.list.append(obj)
 
     def printErr(self, why):
-        print "ERR!"
-        print why.getBriefTraceback()
+        print("ERR!")
+        print(why.getBriefTraceback())
         log.err(why)
 
     def receiveClose(self):
@@ -118,7 +119,7 @@ class ListConstraint(OpenerConstraint):
     accept lists of any length, use maxLength=None. All member objects must
     obey the given constraint."""
 
-    opentypes = [("list",)]
+    opentypes = [(six.b("list"),)]
     name = "ListConstraint"
 
     def __init__(self, constraint, maxLength=None, minLength=0):

--- a/src/foolscap/slicers/root.py
+++ b/src/foolscap/slicers/root.py
@@ -1,7 +1,7 @@
 # -*- test-case-name: foolscap.test.test_banana -*-
 
 import types
-from zope.interface import implements
+from zope.interface import implementer
 from twisted.internet.defer import Deferred
 from foolscap import tokens
 from foolscap.tokens import Violation, BananaError
@@ -11,8 +11,8 @@ from foolscap.slicers.vocab import ReplaceVocabularyTable, AddToVocabularyTable
 from foolscap import copyable # does this create a cycle?
 from twisted.python import log
 
+@implementer(tokens.ISlicer, tokens.IRootSlicer)
 class RootSlicer:
-    implements(tokens.ISlicer, tokens.IRootSlicer)
 
     streamableInGeneral = True
     producingDeferred = None

--- a/src/foolscap/slicers/set.py
+++ b/src/foolscap/slicers/set.py
@@ -1,5 +1,6 @@
 # -*- test-case-name: foolscap.test.test_banana -*-
 
+import six
 from twisted.internet import defer
 from twisted.python import log
 from foolscap.slicers.list import ListSlicer
@@ -116,8 +117,8 @@ class SetUnslicer(BaseUnslicer):
             self.set.add(obj)
 
     def printErr(self, why):
-        print "ERR!"
-        print why.getBriefTraceback()
+        print("ERR!")
+        print(why.getBriefTraceback())
         log.err(why)
 
     def receiveClose(self):
@@ -150,7 +151,7 @@ class SetConstraint(OpenerConstraint):
 
     # TODO: if mutable!=None, we won't throw out the wrong set type soon
     # enough. We need to override checkOpenType to accomplish this.
-    opentypes = [("set",), ("immutable-set",)]
+    opentypes = [(six.b("set"),), (six.b("immutable-set"),)]
     name = "SetConstraint"
 
     def __init__(self, constraint, maxLength=None, mutable=None):

--- a/src/foolscap/slicers/tuple.py
+++ b/src/foolscap/slicers/tuple.py
@@ -1,5 +1,6 @@
 # -*- test-case-name: foolscap.test.test_banana -*-
 
+import six
 from twisted.internet.defer import Deferred
 from foolscap.tokens import Violation
 from foolscap.slicer import BaseUnslicer
@@ -31,7 +32,7 @@ class TupleUnslicer(BaseUnslicer):
         self.num_unreferenceable_children = 0
         self.count = count
         if self.debug:
-            print "%s[%d].start with %s" % (self, self.count, self.list)
+            print("%s[%d].start with %s" % (self, self.count, self.list))
         self.finished = False
         self.deferred = Deferred()
         self.protocol.setObject(count, self.deferred)
@@ -58,7 +59,7 @@ class TupleUnslicer(BaseUnslicer):
 
     def update(self, obj, index):
         if self.debug:
-            print "%s[%d].update: [%d]=%s" % (self, self.count, index, obj)
+            print("%s[%d].update: [%d]=%s" % (self, self.count, index, obj))
         self.list[index] = obj
         self.num_unreferenceable_children -= 1
         if self.finished:
@@ -78,12 +79,12 @@ class TupleUnslicer(BaseUnslicer):
 
     def checkComplete(self):
         if self.debug:
-            print "%s[%d].checkComplete: %d pending" % \
-                  (self, self.count, self.num_unreferenceable_children)
+            print("%s[%d].checkComplete: %d pending" % \
+                  (self, self.count, self.num_unreferenceable_children))
         if self.num_unreferenceable_children:
             # not finished yet, we'll fire our Deferred when we are
             if self.debug:
-                print " not finished yet"
+                print(" not finished yet")
             return
 
         # list is now complete. We can finish.
@@ -96,20 +97,20 @@ class TupleUnslicer(BaseUnslicer):
 
         t = tuple(self.list)
         if self.debug:
-            print " finished! tuple:%s{%s}" % (t, id(t))
+            print(" finished! tuple:%s{%s}" % (t, id(t)))
         self.protocol.setObject(self.count, t)
         self.deferred.callback(t)
         return t, ready_deferred
 
     def receiveClose(self):
         if self.debug:
-            print "%s[%d].receiveClose" % (self, self.count)
+            print("%s[%d].receiveClose" % (self, self.count))
         self.finished = 1
 
         if self.num_unreferenceable_children:
             # not finished yet, we'll fire our Deferred when we are
             if self.debug:
-                print " not finished yet"
+                print(" not finished yet")
             ready_deferred = None
             if self._ready_deferreds:
                 ready_deferred = AsyncAND(self._ready_deferreds)
@@ -123,7 +124,7 @@ class TupleUnslicer(BaseUnslicer):
 
 
 class TupleConstraint(OpenerConstraint):
-    opentypes = [("tuple",)]
+    opentypes = [(six.b("tuple"),)]
     name = "TupleConstraint"
 
     def __init__(self, *elemConstraints):

--- a/src/foolscap/slicers/unicode.py
+++ b/src/foolscap/slicers/unicode.py
@@ -1,14 +1,19 @@
 # -*- test-case-name: foolscap.test.test_banana -*-
 
+import six
 import re
 from twisted.internet.defer import Deferred
 from foolscap.tokens import BananaError, STRING, VOCAB, Violation
 from foolscap.slicer import BaseSlicer, LeafUnslicer
 from foolscap.constraint import OpenerConstraint, Any
 
+if six.PY3:
+    unicode = str
+    
 class UnicodeSlicer(BaseSlicer):
     opentype = ("unicode",)
-    slices = unicode
+    slices = six.text_type
+    
     def sliceBody(self, streamable, banana):
         yield self.obj.encode("UTF-8")
 

--- a/src/foolscap/slicers/vocab.py
+++ b/src/foolscap/slicers/vocab.py
@@ -32,7 +32,7 @@ class ReplaceVocabSlicer(BaseSlicer):
         stringToIndex = self.obj
         indexToString = dict([(stringToIndex[s],s) for s in stringToIndex])
         assert len(stringToIndex) == len(indexToString) # catch duplicates
-        indices = indexToString.keys()
+        indices = list(indexToString.keys())
         indices.sort()
         for index in indices:
             string = indexToString[index]
@@ -85,7 +85,7 @@ class ReplaceVocabUnslicer(LeafUnslicer):
         assert not isinstance(token, Deferred)
         assert ready_deferred is None
         if self.key is None:
-            if self.d.has_key(token):
+            if token in self.d:
                 raise BananaError("duplicate key '%s'" % token)
             self.key = token
         else:

--- a/src/foolscap/storage.py
+++ b/src/foolscap/storage.py
@@ -15,9 +15,9 @@ This functionality is isolated here because it is never used for data coming
 over network connections.
 """
 
-from io import StringIO
 import types
 import six
+from six import StringIO
 import inspect
 from pickle import whichmodule  # used by FunctionSlicer
 
@@ -477,6 +477,7 @@ class SerializerTransport:
         self.sio = sio
     def write(self, data):
         self.sio.write(data)
+            
     def loseConnection(self, why="ignored"):
         pass
 

--- a/src/foolscap/stringchain.py
+++ b/src/foolscap/stringchain.py
@@ -1,4 +1,5 @@
 import copy
+import six
 
 from collections import deque
 
@@ -52,7 +53,7 @@ class StringChain(object):
         if self.d:
             return self.d[0]
         else:
-            return ''
+            return six.b('')
 
     def popleft_new_stringchain(self, bytes):
         """ Remove some of the leading bytes of the chain and return them as a
@@ -98,9 +99,10 @@ class StringChain(object):
     def popleft(self, bytes):
         """ Remove some of the leading bytes of the chain and return them as a
         string. """
+
         #assert self._assert_invariants()
         if not bytes or not self.d:
-            return ''
+            return six.b('')
 
         assert bytes >= 0, bytes
 
@@ -130,7 +132,7 @@ class StringChain(object):
             self.len += overrun
             resstrs[-1] = resstrs[-1][:-overrun]
 
-        resstr = ''.join(resstrs)
+        resstr = six.b('').join([six.ensure_binary(item, 'latin1') for item in resstrs])
 
         # Either you got exactly how many you asked for, or you drained self entirely and you asked for more than you got.
         #assert (len(resstr) == bytes) or ((not self.d) and (bytes > self.len)), (len(resstr), bytes, len(self.d), overrun)
@@ -203,7 +205,7 @@ class StringChain(object):
             self.d[-1] = self.d[-1][:-self.tailignored]
             self.tailignored = 0
         if len(self.d) > 1:
-            newstr = ''.join(self.d)
+            newstr = six.b('').join(self.d)
             self.d.clear()
             self.d.append(newstr)
         #assert self._assert_invariants()

--- a/src/foolscap/test/common.py
+++ b/src/foolscap/test/common.py
@@ -1,7 +1,7 @@
 # -*- test-case-name: foolscap.test.test_pb -*-
 
 import re, time
-from zope.interface import implements, implementsOnly, implementedBy, Interface
+from zope.interface import implementer, implementer_only, implementedBy, Interface
 from twisted.python import log
 from twisted.internet import defer, reactor, task, protocol
 from twisted.application import internet
@@ -104,8 +104,9 @@ class RIHelper(RemoteInterface):
     def mega3(obj1=MegaSchema3): return None
     def choice1(obj1=ChoiceOf(ByteStringConstraint(2000), int)): return None
 
+@implementer(RIHelper)
 class HelperTarget(Referenceable):
-    implements(RIHelper)
+
     d = None
     def __init__(self, name="unnamed"):
         self.name = name
@@ -284,8 +285,8 @@ RIMyTarget3['sub'] = RemoteMethodSchema(_response=int, a=int, b=int)
 RIMyTarget3['sub'].name = "sub"
 RIMyTarget3['sub'].interface = RIMyTarget3
 
+@implementer(RIMyTarget)
 class Target(Referenceable):
-    implements(RIMyTarget)
 
     def __init__(self, name=None):
         self.calls = []
@@ -311,12 +312,13 @@ class Target(Referenceable):
     def remote_failstring(self):
         raise "string exceptions are annoying"
 
+@implementer_only(implementedBy(Referenceable))
 class TargetWithoutInterfaces(Target):
     # undeclare the RIMyTarget interface
-    implementsOnly(implementedBy(Referenceable))
+    pass
 
+@implementer(RIMyTarget)
 class BrokenTarget(Referenceable):
-    implements(RIMyTarget)
 
     def remote_add(self, a, b):
         return "error"
@@ -326,8 +328,9 @@ class IFoo(Interface):
     # non-remote Interface
     pass
 
+@implementer(IFoo)
 class Foo(Referenceable):
-    implements(IFoo)
+    pass
 
 class RIDummy(RemoteInterface):
     pass
@@ -339,11 +342,12 @@ class RITypes(RemoteInterface):
     def takes_interface(a=IFoo): return str
     def returns_interface(work=bool): return IFoo
 
+@implementer(RIDummy)
 class DummyTarget(Referenceable):
-    implements(RIDummy)
+    pass
 
+@implementer(RITypes)
 class TypesTarget(Referenceable):
-    implements(RITypes)
 
     def remote_returns_none(self, work):
         if work:

--- a/src/foolscap/test/test_banana.py
+++ b/src/foolscap/test/test_banana.py
@@ -1856,7 +1856,7 @@ class ThereAndBackAgain(TestBananaMixin, unittest.TestCase):
     def test_string(self):
         return self.looptest("biggles")
     def test_unicode(self):
-        self.looptest("biggles\u1234")
+        self.looptest(six.ensure_text("biggles\u1234"))
     def test_list(self):
         return self.looptest([1,2])
     def test_tuple(self):

--- a/src/foolscap/test/test_banana.py
+++ b/src/foolscap/test/test_banana.py
@@ -268,7 +268,7 @@ class UnbananaTestMixin:
     def failIfBananaFailure(self, res):
         if isinstance(res, BananaFailure):
             # something went wrong
-            print(("There was a failure while Unbananaing '%s':" % res.where))
+            print("There was a failure while Unbananaing '%s':" % res.where)
             print(res.getTraceback())
             self.fail("BananaFailure")
 

--- a/src/foolscap/test/test_banana.py
+++ b/src/foolscap/test/test_banana.py
@@ -1484,12 +1484,12 @@ class InboundByteStream(TestBananaMixin, unittest.TestCase):
         self.check(-127, bINT(-127))
 
     def testLong(self):
-        self.check(int(258), "\x02\x85\x01\x02") # TODO: 0x85 for LONGINT??
-        self.check(int(-258), "\x02\x86\x01\x02") # TODO: 0x85 for LONGINT??
-        self.check(int(0), "\x85")
-        self.check(int(0), "\x00\x85")
-        self.check(int(0), "\x86")
-        self.check(int(0), "\x00\x86")
+        self.check(long(258), "\x02\x85\x01\x02") # TODO: 0x85 for LONGINT??
+        self.check(long(-258), "\x02\x86\x01\x02") # TODO: 0x85 for LONGINT??
+        self.check(long(0), "\x85")
+        self.check(long(0), "\x00\x85")
+        self.check(long(0), "\x86")
+        self.check(long(0), "\x00\x86")
 
     def testString(self):
         self.check("", "\x82")

--- a/src/foolscap/test/test_banana.py
+++ b/src/foolscap/test/test_banana.py
@@ -395,7 +395,7 @@ class TestBananaMixin:
         d = self.loop(obj)
         d.addCallback(self._looptest_1, newvalue)
         return d
-    
+
     def _looptest_1(self, obj2, newvalue):
         if type(obj2) is dict:
             self.assertEqual(dict_key_to_bytes(obj2),
@@ -1856,7 +1856,7 @@ class ThereAndBackAgain(TestBananaMixin, unittest.TestCase):
     def test_string(self):
         return self.looptest("biggles")
     def test_unicode(self):
-        return self.looptest("biggles\\u1234")
+        self.looptest("biggles\u1234")
     def test_list(self):
         return self.looptest([1,2])
     def test_tuple(self):
@@ -1955,8 +1955,8 @@ class ThereAndBackAgain(TestBananaMixin, unittest.TestCase):
             x = six.ensure_text(x)
             y = six.ensure_text(y)
         elif type(x) in (list, tuple):
-            x = list(map(six.ensure_text, x))
-            y = list(map(six.ensure_text, y))
+            x = [six.ensure_text(i) for i in x]
+            y = [six.ensure_text(i) for i in y]
             
         self.assertEqual(x, y)
         self.assertEqual(type(x[0]), type(y[0]))
@@ -2044,8 +2044,7 @@ class VocabTest1(unittest.TestCase):
         b = TokenBanana()
         b.connectionMade()
         vdict = {1: 'list', 2: 'tuple', 3: 'dict'}
-        keys = list(vdict.keys())
-        keys.sort()
+        keys = sorted(vdict.keys())
         setVdict = [tOPEN(0),'set-vocab']
         for k in keys:
             setVdict.append(k)
@@ -2061,8 +2060,7 @@ class VocabTest1(unittest.TestCase):
         b.tokens = []
         strings = ["list", "tuple", "dict"]
         vdict = {0: 'list', 1: 'tuple', 2: 'dict'}
-        keys = list(vdict.keys())
-        keys.sort()
+        keys = sorted(vdict.keys())
         setVdict = [tOPEN(0),'set-vocab']
         for k in keys:
             setVdict.append(k)

--- a/src/foolscap/test/test_crypto.py
+++ b/src/foolscap/test/test_crypto.py
@@ -2,7 +2,7 @@
 import re
 from twisted.trial import unittest
 
-from zope.interface import implements
+from zope.interface import implementer
 from twisted.internet import defer
 from foolscap import pb
 from foolscap.api import RemoteInterface, Referenceable, Tub, flushEventualQueue
@@ -20,8 +20,8 @@ class RIMyCryptoTarget(RemoteInterface):
     def join(a=str, b=str, c=int): return str
     def getName(): return str
 
+@implementer(RIMyCryptoTarget)
 class Target(Referenceable):
-    implements(RIMyCryptoTarget)
 
     def __init__(self, name=None):
         self.calls = []

--- a/src/foolscap/test/test_gifts.py
+++ b/src/foolscap/test/test_gifts.py
@@ -1,5 +1,5 @@
 
-from zope.interface import implements
+from zope.interface import implementer
 from twisted.trial import unittest
 from twisted.internet import defer, protocol, reactor
 from twisted.internet.error import ConnectionRefusedError
@@ -16,8 +16,8 @@ class RIConstrainedHelper(RemoteInterface):
     def set(obj=RIHelper): return None
 
 
+@implementer(RIConstrainedHelper)
 class ConstrainedHelper(Referenceable):
-    implements(RIConstrainedHelper)
 
     def __init__(self, name="unnamed"):
         self.name = name

--- a/src/foolscap/test/test_interfaces.py
+++ b/src/foolscap/test/test_interfaces.py
@@ -1,6 +1,6 @@
 # -*- test-case-name: foolscap.test.test_interfaces -*-
 
-from zope.interface import implementsOnly
+from zope.interface import implementer_only
 from twisted.trial import unittest
 
 from foolscap import schema, remoteinterface
@@ -16,8 +16,9 @@ from foolscap.test.common import getRemoteInterfaceName, Target, RIMyTarget, \
      DummyTarget
 
 
+@implementer_only(IFoo, RIMyTarget2)
 class Target2(Target):
-    implementsOnly(IFoo, RIMyTarget2)
+    pass
 
 class TestInterface(TargetMixin, unittest.TestCase):
 

--- a/src/foolscap/test/test_logging.py
+++ b/src/foolscap/test/test_logging.py
@@ -2,7 +2,7 @@
 import os, sys, json, time, bz2, base64, re
 import mock
 from cStringIO import StringIO
-from zope.interface import implements
+from zope.interface import implementer
 from twisted.trial import unittest
 from twisted.application import service
 from twisted.internet import defer, reactor
@@ -578,8 +578,9 @@ class Incidents(unittest.TestCase, PollMixin, LogfileReaderMixin):
         d.addCallback(_check)
         return d
 
+@implementer(RILogObserver)
 class Observer(Referenceable):
-    implements(RILogObserver)
+
     def __init__(self):
         self.messages = []
         self.incidents = []

--- a/src/foolscap/test/test_reference.py
+++ b/src/foolscap/test/test_reference.py
@@ -1,13 +1,13 @@
 
-from zope.interface import implements
+from zope.interface import implementer
 from twisted.trial import unittest
 from foolscap.ipb import IRemoteReference
 from foolscap.test.common import HelperTarget, Target, ShouldFailMixin
 from foolscap.eventual import flushEventualQueue
 from foolscap import broker, referenceable, api
 
+@implementer(IRemoteReference)
 class Remote:
-    implements(IRemoteReference)
     pass
 
 

--- a/src/foolscap/tokens.py
+++ b/src/foolscap/tokens.py
@@ -1,25 +1,28 @@
 
+from six import int2byte
 from twisted.python.failure import Failure
 from zope.interface import Attribute, Interface
 
+
 # delimiter characters.
-LIST     = chr(0x80) # old
-INT      = chr(0x81)
-STRING   = chr(0x82)
-NEG      = chr(0x83)
-FLOAT    = chr(0x84)
+LIST     = int2byte(0x80) # old
+INT      = int2byte(0x81)
+STRING   = int2byte(0x82)
+NEG      = int2byte(0x83)
+FLOAT    = int2byte(0x84)
 # "optional" -- these might be refused by a low-level implementation.
-LONGINT  = chr(0x85) # old
-LONGNEG  = chr(0x86) # old
+LONGINT  = int2byte(0x85) # old
+LONGNEG  = int2byte(0x86) # old
 # really optional; this is is part of the 'pb' vocabulary
-VOCAB    = chr(0x87)
+VOCAB    = int2byte(0x87)
+
 # newbanana tokens
-OPEN     = chr(0x88)
-CLOSE    = chr(0x89)
-ABORT    = chr(0x8A)
-ERROR    = chr(0x8D)
-PING     = chr(0x8E)
-PONG     = chr(0x8F)
+OPEN     = int2byte(0x88)
+CLOSE    = int2byte(0x89)
+ABORT    = int2byte(0x8A)
+ERROR    = int2byte(0x8D)
+PING     = int2byte(0x8E)
+PONG     = int2byte(0x8F)
 
 tokenNames = {
     LIST: "LIST",
@@ -61,13 +64,16 @@ class Violation(Exception):
 
     def setLocation(self, where):
         self.where = where
+
     def getLocation(self):
         return self.where
+
     def prependLocation(self, prefix):
         if self.where:
             self.where = prefix + " " + self.where
         else:
             self.where = prefix
+
     def appendLocation(self, suffix):
         if self.where:
             self.where = self.where + " " + suffix


### PR DESCRIPTION
This is pulled from the py3kport branch changes for test_banana.py test with enough changes to do an early review for some core modules. It keeps Py2 compatibility and CI tests should also pass.

Let us not worry too much about the code coverage failures for now as this will be a  WIP and it will change. The main thing is that the CI tests pass.

Briefly the changes are,

```
1. Zope implements -> @implementer decorator and related changes for a few modules.
2. The following modules ported to Python2 compatible 3
   1. banana.py
   2. tokens.py
   3. storage.py
   4. slicers/root.py
   5. slicer.py
```

You can try and look for the places marked with "PY3KPORT". I have tried to be consistent in this in most changes. Thanks.