### PR TITLE
appserver: remote_putfile uses bytes on wire

### DIFF
--- a/src/foolscap/appserver/client.py
+++ b/src/foolscap/appserver/client.py
@@ -26,7 +26,7 @@ class UploadFileOptions(BaseOptions):
 class Uploader(Referenceable):
     def run(self, rref, sourcefile, name):
         self.f = open(os.path.expanduser(sourcefile), "rb")
-        return rref.callRemote("putfile", name, self)
+        return rref.callRemote("putfile", six.ensure_binary(name), self)
 
     def remote_read(self, size):
         return self.f.read(size)

--- a/src/foolscap/appserver/services.py
+++ b/src/foolscap/appserver/services.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 import os
+import six
 from twisted.python import usage, runtime, filepath, log
 from twisted.application import service
 from twisted.internet import defer, reactor, protocol
@@ -94,6 +95,7 @@ class FileUploader(service.MultiService, Referenceable):
         self.targetdir = filepath.FilePath(options.targetdir)
 
     def remote_putfile(self, name, source):
+        name = six.ensure_str(name)
         #if "/" in name or name == "..":
         #    raise BadFilenameError()
         #targetfile = os.path.join(self.options.targetdir, name)


### PR DESCRIPTION
and converts into a native str upon receipt

Hopefully this will enable "flappclient upload-file" to work between py2/py3
systems, but I haven't tested it yet.