### PR TITLE
Support unicode method names in callRemote() on Python 2

### DIFF
--- a/src/foolscap/referenceable.py
+++ b/src/foolscap/referenceable.py
@@ -558,6 +558,8 @@ class RemoteReference(RemoteReferenceOnly):
         return req.deferred
 
     def _getMethodInfo(self, name):
+        if six.PY2 and isinstance(name, six.text_type):
+            name = name.encode("utf-8")
         assert type(name) is str
         interfaceName = None
         methodName = name

--- a/src/foolscap/referenceable.py
+++ b/src/foolscap/referenceable.py
@@ -558,9 +558,7 @@ class RemoteReference(RemoteReferenceOnly):
         return req.deferred
 
     def _getMethodInfo(self, name):
-        if six.PY2 and isinstance(name, six.text_type):
-            name = name.encode("utf-8")
-        assert type(name) is str
+        name = six.ensure_str(name)
         interfaceName = None
         methodName = name
         methodSchema = None


### PR DESCRIPTION
Fixes #72 

Couldn't figure out how to test this, couldn't reproduce the problem outside of Tahoe-LAFS, so suggestion on where to add a test would be welcome. On Tahoe the object with the `callRemote` was:

```
<RemoteReference at 0x7f18c6ddf0d0 [pb://4vg727bxx5demij34tyl2zz6hgnwnomh@tcp:127.0.0.1:38561/455kvjrkirtmw2ggtnr7gt6lkeq3v5kz]>
```