### PR TITLE
Hardcode older tox, and drop 2.7 and 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     name: "${{ matrix.os }}: Python ${{ matrix.python-version }}"
     strategy:
       matrix:
-        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9"]
         os: ["ubuntu-18.04"]
 
     runs-on: "${{ matrix.os }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,5 +25,5 @@ jobs:
         with:
           python-version: "${{ matrix.python-version }}"
       - run: |
-          pip install tox tox-gh-actions
+          pip install 'tox<4' tox-gh-actions
           tox

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,8 @@ object reference system, and a capability-based security model.
         "i2p": ["txi2p-tahoe >= 0.3.5; python_version > '3.0'",
                 "txi2p >= 0.3.2; python_version < '3.0'"],
         },
+    # We support Python 3.7 or later. 3.11 is not supported yet.
+    "python_requires": ">=3.7, <3.11",
 }
 
 setup_args.update(
@@ -87,4 +89,3 @@ setup_args.update(
 
 if __name__ == "__main__":
     setup(**setup_args)
-

--- a/src/foolscap/test/common.py
+++ b/src/foolscap/test/common.py
@@ -545,7 +545,7 @@ class BaseMixin(ShouldFailMixin):
         except ImportError:
             raise unittest.SkipTest('this test needs twisted.web')
         root = resource.Resource()
-        root.putChild("", static.Data("hello\n", "text/plain"))
+        root.putChild(b"", static.Data("hello\n", "text/plain"))
         s = internet.TCPServer(0, server.Site(root))
         s.startService()
         self.services.append(s)

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
-envlist = py27,py36,py37,py38,py39
+envlist = py37,py38,py39
 skip_missing_interpreters = True
 minversion = 2.4.0
 
 [gh-actions]
 python =
-       2.7: py27
-       3.6: py36
        3.7: py37
        3.8: py38
        3.9: py39


### PR DESCRIPTION
Fixes #95 

1. Hard code older tox
2. Drop 2.7 and 3.6
3. Make tests pass again (supersedes #92)