### PR TITLE
remove dependency on old mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ object reference system, and a capability-based security model.
     "cmdclass": commands,
     "install_requires": ["six", "twisted[tls] >= 16.0.0", "pyOpenSSL"],
     "extras_require": {
-        "dev": ["mock", "txtorcon >= 19.0.0",
+        "dev": ["txtorcon >= 19.0.0",
                 "txi2p-tahoe >= 0.3.5; python_version > '3.0'",
                 "txi2p >= 0.3.2; python_version < '3.0'",
                 "pywin32 ; sys_platform == 'win32'"],

--- a/src/foolscap/test/test_connection.py
+++ b/src/foolscap/test/test_connection.py
@@ -1,5 +1,5 @@
 import os
-import mock
+from unittest import mock
 from zope.interface import implementer
 from twisted.trial import unittest
 from twisted.internet import endpoints, defer, reactor

--- a/src/foolscap/test/test_logging.py
+++ b/src/foolscap/test/test_logging.py
@@ -1,7 +1,7 @@
 
 import os, sys, json, time, bz2, base64, re
 import six
-import mock
+from unittest import mock
 from io import StringIO
 from zope.interface import implementer
 from twisted.trial import unittest


### PR DESCRIPTION
https://github.com/testing-cabal/mock

"mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards."