### PR TITLE
Work with next release of Twisted, and run tests on Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,14 +14,14 @@ jobs:
     name: "${{ matrix.os }}: Python ${{ matrix.python-version }}"
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev"]
         os: ["ubuntu-22.04"]
 
     runs-on: "${{ matrix.os }}"
 
     steps:
-      - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v2"
+      - uses: "actions/checkout@v4"
+      - uses: "actions/setup-python@v5"
         with:
           python-version: "${{ matrix.python-version }}"
       - run: |

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /.coverage
 /coverage.xml
 /.tox/
+venv*

--- a/src/foolscap/test/test_interfaces.py
+++ b/src/foolscap/test/test_interfaces.py
@@ -112,33 +112,6 @@ class TestInterface(TargetMixin, unittest.TestCase):
         iface = getRemoteInterface(t)
         self.assertFalse(iface)
 
-    def testStack(self):
-        # when you violate your outbound schema, the Failure you get should
-        # have a stack trace that includes the actual callRemote invocation.
-        # Sometimes the stack trace doesn't include source code (either we
-        # have .pyc files but not .py files, or because the code is coming
-        # from an .egg). So this test merely asserts that test_interfaces.py
-        # is present in the trace, followed by either a source code line that
-        # mentions callRemote, or the filename/linenumber/functionname line
-        # that mentions callRemote.
-        self.setupBrokers()
-        rr, target = self.setupTarget(Target(), True)
-        d = rr.callRemote('add', "not a number", "oops")
-        def _check_failure(f):
-            s = f.getTraceback().split("\n")
-            for i in range(len(s)):
-                line = s[i]
-                if ("test_interfaces.py" in line
-                    and i+2 < len(s)
-                    and ("rr.callRemote" in s[i+1]
-                         or "in callRemote" in s[i+2])):
-                    return # all good
-            print("failure looked like this:")
-            print(f)
-            self.fail("didn't see invocation of callRemote in stacktrace")
-        d.addCallbacks(lambda res: self.fail("hey, this was supposed to fail"),
-                       _check_failure)
-        return d
 
 class Types(TargetMixin, unittest.TestCase):
     def setUp(self):

--- a/src/foolscap/test/test_logging.py
+++ b/src/foolscap/test/test_logging.py
@@ -1794,7 +1794,7 @@ class Tail(unittest.TestCase):
                         outmsg)
         self.assertTrue("RuntimeError" in outmsg, outmsg)
         self.assertTrue(": fake error" in outmsg, outmsg)
-        self.assertTrue("--- <exception caught here> ---\n" in outmsg, outmsg)
+        self.assertTrue("test_logging.py" in outmsg, outmsg)
 
     def test_logprinter_verbose(self):
         target_tubid_s = "jiijpvbge2e3c3botuzzz7la3utpl67v"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,py311
+envlist = py37,py38,py39,py310,py311,py312,py313
 skip_missing_interpreters = True
 minversion = 2.4.0
 
@@ -10,9 +10,11 @@ python =
        3.9: py39
        3.10: py310
        3.11: py311
+       3.12: py312
+       3.13: py313
 
 [testenv]
-passenv = USERPROFILE HOMEDRIVE HOMEPATH PYTHONWARNINGS
+passenv = USERPROFILE,HOMEDRIVE,HOMEPATH,PYTHONWARNINGS
 usedevelop = True
 extras = dev
 deps =


### PR DESCRIPTION
Next release of Twisted will have different tracebacks in Failures (omitting the stack of Failure creation).