### PR TITLE
Stop using twisted.internet.defer.returnValue

### DIFF
--- a/src/foolscap/connections/tor.py
+++ b/src/foolscap/connections/tor.py
@@ -1,7 +1,7 @@
 import os, re
 import six
 from twisted.internet.interfaces import IStreamClientEndpoint
-from twisted.internet.defer import inlineCallbacks, returnValue, succeed
+from twisted.internet.defer import inlineCallbacks, succeed
 from twisted.internet.endpoints import clientFromString
 import ipaddress
 from .. import observer
@@ -71,7 +71,7 @@ class _Common:
             socks_endpoint = yield self._maybe_connect(reactor, update_status)
         ep = txtorcon.TorClientEndpoint(host, portnum,
                                         socks_endpoint=socks_endpoint)
-        returnValue( (ep, host) )
+        return ep, host
 
     def describe(self):
         return "tor"
@@ -133,7 +133,7 @@ class _LaunchedTor(_Common):
         #print "launched"
         # gives a TorProcessProtocol with .tor_protocol
         self._tor_protocol = tpp.tor_protocol
-        returnValue(socks_endpoint)
+        return socks_endpoint
 
 def launch(data_directory=None, tor_binary=None):
     """Return a handler which launches a new Tor process (once).
@@ -189,7 +189,7 @@ class _ConnectedTor(_Common):
         try:
             (socks_endpoint, socks_desc) = next(find_port(reactor, ports))
             self._socks_desc = socks_desc # stash for tests
-            returnValue(socks_endpoint)
+            return socks_endpoint
         except StopIteration:
             raise ValueError("could not use config.SocksPort: %r" % (ports,))
 

--- a/src/foolscap/logging/web.py
+++ b/src/foolscap/logging/web.py
@@ -2,7 +2,7 @@ import time
 import six
 from six.moves.urllib.parse import quote
 from twisted.internet import reactor, endpoints
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from twisted.python import usage
 from foolscap import base32
 from foolscap.eventual import fireEventually
@@ -395,7 +395,7 @@ class WebViewer:
             import webbrowser
             webbrowser.open(url)
 
-        returnValue(url) # for tests
+        return url # for tests
 
     def stop(self):
         return self.lp.stopListening()

--- a/src/foolscap/test/test_logging.py
+++ b/src/foolscap/test/test_logging.py
@@ -7,7 +7,7 @@ from zope.interface import implementer
 from twisted.trial import unittest
 from twisted.application import service
 from twisted.internet import defer, reactor
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 try:
     from twisted import logger as twisted_logger
 except ImportError:
@@ -2332,7 +2332,7 @@ def getPage(url):
     if response.code != 200:
         raise ValueError("request failed (%d), page contents were: %s" % (
             response.code, six.ensure_str(page)))
-    returnValue(page)
+    return page
 
 class Web(unittest.TestCase):
     def setUp(self):

--- a/src/foolscap/test/test_negotiate.py
+++ b/src/foolscap/test/test_negotiate.py
@@ -2,7 +2,7 @@
 from twisted.trial import unittest
 
 from twisted.internet import protocol, defer, reactor
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from twisted.application import internet
 from twisted.web.client import Agent
 from foolscap import negotiate, tokens
@@ -386,7 +386,7 @@ class CrossfireMixin(BaseMixin, PollMixin):
         # connection to be dropped, which will happen shortly after the
         # forward direction is established (but after some network traffic).
         yield self.poll(lambda: self.tub2phases)
-        returnValue(rref1)
+        return rref1
 
     def checkConnectedViaReverse(self, rref, targetPhases):
         # assert that connection[0] (from tub1 to tub2) is actually in use.


### PR DESCRIPTION
`defer.returnValue` was only needed in Python 2; in Python 3, a simple `return` is fine.

`twisted.internet.defer.returnValue` is deprecated as of Twisted 24.7.0.