### PR TITLE
Fix a SyntaxWarning due to an invalid escape sequence

### DIFF
--- a/src/foolscap/logging/gatherer.py
+++ b/src/foolscap/logging/gatherer.py
@@ -518,8 +518,7 @@ class IncidentGathererService(GatheringBase, IncidentClassifierBase):
         return categories
 
 
-INCIDENT_GATHERER_TACFILE = """\
-# -*- python -*-
+INCIDENT_GATHERER_TACFILE = r"""# -*- python -*-
 
 # we record the path when 'flogtool create-incident-gatherer' is run, in case
 # flogtool was run out of a source tree. This is somewhat fragile, of course.


### PR DESCRIPTION
Fixes #115.

Only a single change since the second SyntaxWarning was already fixed in 911a45136653b8797381a92955a792469a1b927b .